### PR TITLE
Don't allow undefined skew to always return true for time_in_bounds

### DIFF
--- a/src/chef_time_utils.erl
+++ b/src/chef_time_utils.erl
@@ -62,6 +62,10 @@ canonical_time(T) when is_list(T) ->
     time_iso8601(httpd_util:convert_request_date(T)).
 
 -spec time_in_bounds(undefined | string() | binary(), time_skew()) -> boolean() | invalid_reqtime.
+%% @doc Check if a time, expressed as an ISO8601 string is equal to the current time, within
+%% a given Skew interval.
+%%
+%% Returns invalid_reqtime if the ISO8601 time can't be parsed
 time_in_bounds(undefined, _Skew) ->
     false;
 time_in_bounds(ReqTime, Skew) ->
@@ -74,7 +78,9 @@ time_in_bounds(ReqTime, Skew) ->
     end.
 
 -spec time_in_bounds(erlang_time(), erlang_time(), time_skew() ) -> boolean().
-time_in_bounds(T1, T2, Skew) ->
+%% @doc Check if two times are equal within a given Skew interval.
+%%
+time_in_bounds(T1, T2, Skew) when is_integer(Skew) ->
     S1 = calendar:datetime_to_gregorian_seconds(T1),
     S2 = calendar:datetime_to_gregorian_seconds(T2),
     (S2 - S1) < Skew.

--- a/test/chef_time_utils_tests.erl
+++ b/test/chef_time_utils_tests.erl
@@ -36,3 +36,10 @@ time_in_bounds_test() ->
     ?assertEqual(false, chef_time_utils:time_in_bounds(T1, T4, 60*60)),
     ?assertEqual(true, chef_time_utils:time_in_bounds(T1, T4, 60*60*3)).
 
+%% We expect no function match when Skew is undefined
+undefined_skew_test() ->
+    T1 = {{2011,1,26},{2,3,0}},
+    T2 = {{2011,1,26},{2,3,4}},
+
+    ?assertError(function_clause, chef_time_utils:time_in_bounds(T1, T2, undefined)).
+


### PR DESCRIPTION
in time_for_bounds/3 we check if in bounds with

  T2 - T1 < Skew.

If Skew =:= undefined, this alway returns true whereas it should really be false
(or an error condition).  This patch fixes it to return false when Skew =:= undefined.
