### PR TITLE
Convert to envy

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,3 +3,8 @@
 
 {cover_enabled, true}.
 {cover_print_enabled, true}.
+{deps, [
+          {envy, ".*",
+   {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}
+
+ ]}.


### PR DESCRIPTION
Application:get_env requires validation of data types.  This logic has been 
duplicated several times.  This attempts to consolidate validation to a single
library, envy.
