### PR TITLE
Adding signing version 1.3

### DIFF
--- a/src/chef_authn.hrl
+++ b/src/chef_authn.hrl
@@ -27,14 +27,21 @@
 
 -define(BUF_SIZE, 16384).
 
--define(DEFAULT_SIGNING_ALGORITHM, <<"sha1">>).
+-define(SIGNING_ALGORITHM_SHA1, <<"sha1">>).
+-define(SIGNING_ALGORITHM_SHA256, <<"sha256">>).
+
+-define(DEFAULT_SIGNING_ALGORITHM, ?SIGNING_ALGORITHM_SHA1).
 
 -define(SIGNING_VERSION_V1_0, <<"1.0">>).
 -define(SIGNING_VERSION_V1_1, <<"1.1">>).
 -define(SIGNING_VERSION_V1_2, <<"1.2">>).
+-define(SIGNING_VERSION_V1_3, <<"1.3">>).
 
 %% version 1.2 incorporates the related but slightly different RSA PKCS 1.5 SHA+RSA signing method
--define(SIGNING_VERSIONS, [?SIGNING_VERSION_V1_0, ?SIGNING_VERSION_V1_1, ?SIGNING_VERSION_V1_2]).
+-define(SIGNING_VERSIONS, [?SIGNING_VERSION_V1_0,
+                           ?SIGNING_VERSION_V1_1,
+                           ?SIGNING_VERSION_V1_2,
+                           ?SIGNING_VERSION_V1_3]).
 
 -define(SIGNING_VERSION_KEY, <<"version">>).
 

--- a/src/chef_authn.hrl
+++ b/src/chef_authn.hrl
@@ -61,7 +61,7 @@
                                "X-Ops-Content-Hash:~s\n"
                                "X-Ops-Sign:algorithm=~s;version=~s\n"
                                "X-Ops-Timestamp:~s\n"
-                               "X-Ops-UserId:~ts\n"
+                               "X-Ops-UserId:~s\n"
                                "X-Ops-Server-API-Version:~B">>).
 
 -define(REQUIRED_HEADERS, [<<"X-Ops-UserId">>,

--- a/src/chef_authn.hrl
+++ b/src/chef_authn.hrl
@@ -51,6 +51,15 @@
                                "X-Ops-Content-Hash:~s\n"
                                "X-Ops-Timestamp:~s\nX-Ops-UserId:~ts">>).
 
+%% The version 1.3 format includes the X-Ops-Sign and X-Ops-Server-API-Version
+%% headers. Thus, it will work only for Chef Server.
+-define(VERSION1_3_SIG_FORMAT, <<"Method:~s\nHashed Path:~s\n"
+                               "X-Ops-Content-Hash:~s\n"
+                               %"X-Ops-Server-API-Version:~s\n"
+                               "X-Ops-Sign:algorithm=~s;version=~s\n"
+                               "X-Ops-Timestamp:~s\n"
+                               "X-Ops-UserId:~ts">>).
+
 -define(REQUIRED_HEADERS, [<<"X-Ops-UserId">>,
                            <<"X-Ops-Timestamp">>,
                            <<"X-Ops-Sign">>,

--- a/test/chef_authn_tests.erl
+++ b/test/chef_authn_tests.erl
@@ -588,6 +588,9 @@ authenticate_user_request_no_body_test_() ->
               ?assertEqual({name, ?user}, Ok)
      end].
 
+authenticate_user_request_1_3_test_() ->
+    authenticate_user_request_tests_by_version(<<"1.3">>).
+
 authenticate_user_request_1_2_test_() ->
     authenticate_user_request_tests_by_version(<<"1.2">>).
 

--- a/test/chef_authn_tests.erl
+++ b/test/chef_authn_tests.erl
@@ -14,7 +14,7 @@
 -define(path, <<"/organizations/clownco">>).
 -define(path_with_query, <<"/organizations/clownco?a=1&b=2">>).
 -define(hashed_path_sha1, <<"YtBWDn1blGGuFIuKksdwXzHU9oE=">>).
--define(hashed_path_sha256, <<"3EsTMw/UBNY9n+q+WBWTJmeVg8hQFbdFzVWRxW4dOA=">>).
+-define(hashed_path_sha256, <<"Z3EsTMw/UBNY9n+q+WBWTJmeVg8hQFbdFzVWRxW4dOA=">>).
 
 -define(body, <<"Spec Body">>).
 -define(hashed_body_sha1, <<"DFteJZPVv6WKdQmMqZUQUumUyRs=">>).
@@ -63,25 +63,27 @@
 
 -define(X_OPS_AUTHORIZATION_LINES_V1_3_SHA1,
         [
-          "HtjhPysvmPf7mFHZ+Ze4rLMucDv4ImPxv5kdJghpVwLo9tuE6VSmbuh3tIBp",
-          "OmVH1sKOqyv6x5fkLaHq0FIYTEgcdXrN86rkFJBvExRzOuL7JHGXKIIzohc9",
-          "BZBcF2LAGv2UY33TMXLhQYIIKh/5uWYZ7QsHjadgWo5nEiFpiy5VCoMKidmr",
-          "DH7jYUZeXCFMgfsLlN6mlilc/iAGnktJwhAQPvIDgJS1cOHqFeWzaU2FRjvQ",
-          "h6AUrsvhJ6C/5uJu6h0DT4uk5w5uVameyI/Cs+0KI/XLCk27dOl4X+SqBN9D",
-          "FDp0m8rzMtOdsPkO/IAgbdpHTWoh8AXmPhh8t6+PfQ=="
+         "wVDg3X99mxxQr1Ox/KJc+zy7b/mPX/M1+jsta5Qht43UhkNq3spRqup8vP26",
+         "TT/0pSSDnJ//wlYnxrEP+izgRGO3n4rwLQNM/ePB+dOXSiOwLDJOl7yChUde",
+         "qrxX6xsaIps6+Di/DRQ1jqLBO5KHkt8Ndc6KUeyV4Dbz/O4+8VIJw0j22Sne",
+         "6kWG648yVrS/ODeHfPGw2kLa1bQ1X7uEpNpOG2l1zzgm19wXZYllnjZphcll",
+         "lItQ/00hM7BgbSJWcqu8tShXlZUv6/ScClQZmkdN3mNojgmlt1fMv2LjejD1",
+         "8I8xfPcfBKelkz4bLHsB86pMvvE+g9tC+h2EvYU2Rw=="
         ]).
 
 -define(X_OPS_AUTHORIZATION_LINES_V1_3_SHA256,
         [
-         "fCmTB4WQoaaz68Zj2k7XBp2HujnqNuq7WGERIVZy2BxYhM4t/MZu8ok3jB+W",
-         "WwvSEYlx63AT5FN6Eo5jkB0l2cdb5fc4Ex2KuNB7JVOoChz8n0WKYWURRNtu",
-         "NFq6Iy9sSNqPPMiooS43IbqGvDgw1VfHQTOAvkbsDua9mTuYW+JtDD4NRFGo",
-         "YhPKM4jOPm5GaygvGkrigSfhOUMt5W2Q1swZdBkmYFhvRbDKNH2zxrzozNOj",
-         "IZgsA8aTYKGjMndt9rJ4H6mWQVOOiE4iE57VwGfGVvFicPeTQSw8zr7/K6E3",
-         "A5G4RQcWxNRisCKQuUo6LBMwY67+Bhk9pJbZ3bD38w=="
-        ]).
+         "Zo20R014Yt3IjMCsUVbOCoctwHOHaxsC3b6dPqmk3xIZo1zmOgVbsHzL72Bt",
+         "cRAeqm/gXHRNJlo4Fbh4jTJP3IBAm+mhga6aMZhRkrVUYfnZ1oEi8f/Z9WyY",
+         "uYPD8iygCEyFj2BshWsvo+lv3EvlmYlh5cKqjqaStLtGB118vfoTAf+XqK/y",
+         "tW4Ye6yn8KddnT/mLMqKJgy8PEbr+jVdLA7wDTZd64++IleNmgK72qneMEjk",
+         "4zuU5JWYfnT3MzyKR7sCsuEvxUNn/o4u5GEuuud2oP8dJUraNNUXpJYk9Us7",
+         "yZS3bUNsFPFVP3RAQadLX9gvC4eAZadTuly0wi0Edg=="
+        ]
+       ).
 
 -define(X_OPS_CONTENT_HASH, "DFteJZPVv6WKdQmMqZUQUumUyRs=").
+-define(X_OPS_CONTENT_HASH_SHA256, "hDlKNZhIhgso3Fs0S0pZwJ0xyBWtR1RBaeHs1DrzOho=").
 
 -define(expected_sign_string_v10,
         iolist_to_binary(io_lib:format(
@@ -114,9 +116,11 @@
         iolist_to_binary(io_lib:format(
                            "Method:~s\nHashed Path:~s\n"
                            "X-Ops-Content-Hash:~s\n"
+                           "X-Ops-Sign:algorithm=~s;version=~s\n"
                            "X-Ops-Timestamp:~s\n"
                            "X-Ops-UserId:~s",
                            ["POST", ?hashed_path_sha1, ?hashed_body_sha1,
+                            ?SIGNING_ALGORITHM_SHA1, ?SIGNING_VERSION_V1_3,
                             ?request_time_iso8601,
                             chef_authn:hash_string(?user,
                                                    {?SIGNING_ALGORITHM_SHA1,
@@ -126,9 +130,11 @@
         iolist_to_binary(io_lib:format(
                            "Method:~s\nHashed Path:~s\n"
                            "X-Ops-Content-Hash:~s\n"
+                           "X-Ops-Sign:algorithm=~s;version=~s\n"
                            "X-Ops-Timestamp:~s\n"
                            "X-Ops-UserId:~s",
                            ["POST", ?hashed_path_sha256, ?hashed_body_sha256,
+                            ?SIGNING_ALGORITHM_SHA256, ?SIGNING_VERSION_V1_3,
                             ?request_time_iso8601,
                             chef_authn:hash_string(?user,
                                                    {?SIGNING_ALGORITHM_SHA256,
@@ -302,6 +308,55 @@ sign_request_1_2_test() ->
     Sig = chef_authn:sign_request(Private_key, ?body, ?user, <<"post">>,
                        ?request_time_erlang, ?path, Algorithm, Version),
     ?assertEqual(EXPECTED_SIGN_RESULT, Sig).
+
+sign_request_1_3_sha1_test() ->
+    Algorithm = <<"sha1">>,
+    Version = <<"1.3">>,
+    {ok, RawKey} = file:read_file("../test/private_key"),
+    Private_key = chef_authn:extract_private_key(RawKey),
+    AuthLine = fun(I) -> lists:nth(I, ?X_OPS_AUTHORIZATION_LINES_V1_3_SHA1) end,
+    EXPECTED_SIGN_RESULT =
+        [
+         {"X-Ops-Content-Hash", ?X_OPS_CONTENT_HASH},
+         {"X-Ops-UserId", ?X_OPS_USERID},
+         {"X-Ops-Sign", "algorithm=sha1;version=1.3"},
+         {"X-Ops-Timestamp", ?request_time_iso8601},
+         {"X-Ops-Authorization-1", AuthLine(1)},
+         {"X-Ops-Authorization-2", AuthLine(2)},
+         {"X-Ops-Authorization-3", AuthLine(3)},
+         {"X-Ops-Authorization-4", AuthLine(4)},
+         {"X-Ops-Authorization-5", AuthLine(5)},
+         {"X-Ops-Authorization-6", AuthLine(6)}
+        ],
+    Sig = chef_authn:sign_request(Private_key, ?body, ?user, <<"post">>,
+                       ?request_time_erlang, ?path, Algorithm, Version),
+    ?assertEqual(EXPECTED_SIGN_RESULT, Sig).
+
+sign_request_1_3_sha256_test() ->
+    Algorithm = <<"sha256">>,
+    Version = <<"1.3">>,
+    {ok, RawKey} = file:read_file("../test/private_key"),
+    Private_key = chef_authn:extract_private_key(RawKey),
+    AuthLine = fun(I) -> lists:nth(I, ?X_OPS_AUTHORIZATION_LINES_V1_3_SHA256) end,
+    EXPECTED_SIGN_RESULT =
+        [
+         {"X-Ops-Content-Hash", ?X_OPS_CONTENT_HASH_SHA256},
+         {"X-Ops-UserId", ?X_OPS_USERID},
+         {"X-Ops-Sign", "algorithm=sha256;version=1.3"},
+         {"X-Ops-Timestamp", ?request_time_iso8601},
+         {"X-Ops-Authorization-1", AuthLine(1)},
+         {"X-Ops-Authorization-2", AuthLine(2)},
+         {"X-Ops-Authorization-3", AuthLine(3)},
+         {"X-Ops-Authorization-4", AuthLine(4)},
+         {"X-Ops-Authorization-5", AuthLine(5)},
+         {"X-Ops-Authorization-6", AuthLine(6)}
+        ],
+    Sig = chef_authn:sign_request(Private_key, ?body, ?user, <<"post">>,
+                       ?request_time_erlang, ?path, Algorithm, Version),
+    ?assertEqual(EXPECTED_SIGN_RESULT, Sig).
+
+
+
 
 sign_bogus_request_test() ->
     ?assertError({missing_required_data, _},

--- a/test/chef_authn_tests.erl
+++ b/test/chef_authn_tests.erl
@@ -281,7 +281,7 @@ verify_sig_v1_2_test() ->
                                        Sig,
                                        list_to_binary(?X_OPS_USERID),
                                        Public_key,
-                                       <<"1.2">>)).
+                                       {<<"sha1">>, <<"1.2">>})).
 
 fetch_keys(BaseDir, Filenames) ->
     Keys = [{N,K} || {N, {ok, K}} <-  [ {Name, file:read_file(iolist_to_binary([ BaseDir, Name]))} || Name <- Filenames ] ],
@@ -299,7 +299,7 @@ verify_sigs_v1_2_test_() ->
                                              Sig,
                                              list_to_binary(?X_OPS_USERID),
                                              KeyList,
-                                             <<"1.2">>),
+                                             {<<"sha1">>, <<"1.2">>}),
               ?assertEqual({name,<<"spec-user">>, "example_cert.pem"}, AuthN)
       end,
       fun() ->
@@ -309,7 +309,7 @@ verify_sigs_v1_2_test_() ->
                                              Sig,
                                              list_to_binary(?X_OPS_USERID),
                                              KeyList2,
-                                             <<"1.2">>),
+                                             {<<"sha1">>, <<"1.2">>}),
               ?debugVal(AuthN),
               ?assertEqual({name,<<"spec-user">>, "example_cert.pem"}, AuthN)
       end,
@@ -321,7 +321,7 @@ verify_sigs_v1_2_test_() ->
                                                       Sig,
                                                       list_to_binary(?X_OPS_USERID),
                                                       KeyList2,
-                                                      <<"1.2">>))
+                                                      {<<"sha1">>, <<"1.2">>}))
       end
     ].
 

--- a/test/chef_authn_tests.erl
+++ b/test/chef_authn_tests.erl
@@ -13,10 +13,12 @@
 
 -define(path, <<"/organizations/clownco">>).
 -define(path_with_query, <<"/organizations/clownco?a=1&b=2">>).
--define(hashed_path, <<"YtBWDn1blGGuFIuKksdwXzHU9oE=">>).
+-define(hashed_path_sha1, <<"YtBWDn1blGGuFIuKksdwXzHU9oE=">>).
+-define(hashed_path_sha256, <<"3EsTMw/UBNY9n+q+WBWTJmeVg8hQFbdFzVWRxW4dOA=">>).
 
 -define(body, <<"Spec Body">>).
--define(hashed_body, <<"DFteJZPVv6WKdQmMqZUQUumUyRs=">>).
+-define(hashed_body_sha1, <<"DFteJZPVv6WKdQmMqZUQUumUyRs=">>).
+-define(hashed_body_sha256, <<"hDlKNZhIhgso3Fs0S0pZwJ0xyBWtR1RBaeHs1DrzOho=">>).
 -define(request_time_http, <<"Thu, 01 Jan 2009 12:00:00 GMT">>).
 -define(request_time_iso8601, "2009-01-01T12:00:00Z").
 -define(request_time_erlang, {{2009, 1, 1}, {12, 0, 0}}).
@@ -59,15 +61,25 @@
           "FDp0m8rzMtOdsPkO/IAgbdpHTWoh8AXmPhh8t6+PfQ=="
         ]).
 
--define(X_OPS_AUTHORIZATION_LINES_V1_3,
-       [
-          "hWMV3mEhEeYAx0GhaSbJlwJgHa7mjxXZv4kLT0mvqbX4zTBNy3SAqBplv3ZZ",
-          "vJbSHgVU4upqerGBHghuRA9BFsDR0iys22z0ArPG1Cbw6BqMVXzyX5MKmHhr",
-          "cxjeHqvFJij+RE7hBiBxqOJ3e80Ri9lz9QmzYJe+SBO+SHTgBS+EnV6KfntR",
-          "GmYOYZ0qqyiGGpdZOjlF9PczPGD6jSYBquVmYKt77hx4gqq4w3Yy4B0naqsp",
-          "YWtomwA4CqboQhMAN9bV50Qg3u0Kc+Nn24/wzRRRbVqznb7PdxuZTnuwZHro",
-          "HPzpjLBLoowOmpInQDSHO0XFetEOyKAgKIaIRQhAWg=="
-       ]).
+-define(X_OPS_AUTHORIZATION_LINES_V1_3_SHA1,
+        [
+          "HtjhPysvmPf7mFHZ+Ze4rLMucDv4ImPxv5kdJghpVwLo9tuE6VSmbuh3tIBp",
+          "OmVH1sKOqyv6x5fkLaHq0FIYTEgcdXrN86rkFJBvExRzOuL7JHGXKIIzohc9",
+          "BZBcF2LAGv2UY33TMXLhQYIIKh/5uWYZ7QsHjadgWo5nEiFpiy5VCoMKidmr",
+          "DH7jYUZeXCFMgfsLlN6mlilc/iAGnktJwhAQPvIDgJS1cOHqFeWzaU2FRjvQ",
+          "h6AUrsvhJ6C/5uJu6h0DT4uk5w5uVameyI/Cs+0KI/XLCk27dOl4X+SqBN9D",
+          "FDp0m8rzMtOdsPkO/IAgbdpHTWoh8AXmPhh8t6+PfQ=="
+        ]).
+
+-define(X_OPS_AUTHORIZATION_LINES_V1_3_SHA256,
+        [
+         "fCmTB4WQoaaz68Zj2k7XBp2HujnqNuq7WGERIVZy2BxYhM4t/MZu8ok3jB+W",
+         "WwvSEYlx63AT5FN6Eo5jkB0l2cdb5fc4Ex2KuNB7JVOoChz8n0WKYWURRNtu",
+         "NFq6Iy9sSNqPPMiooS43IbqGvDgw1VfHQTOAvkbsDua9mTuYW+JtDD4NRFGo",
+         "YhPKM4jOPm5GaygvGkrigSfhOUMt5W2Q1swZdBkmYFhvRbDKNH2zxrzozNOj",
+         "IZgsA8aTYKGjMndt9rJ4H6mWQVOOiE4iE57VwGfGVvFicPeTQSw8zr7/K6E3",
+         "A5G4RQcWxNRisCKQuUo6LBMwY67+Bhk9pJbZ3bD38w=="
+        ]).
 
 -define(X_OPS_CONTENT_HASH, "DFteJZPVv6WKdQmMqZUQUumUyRs=").
 
@@ -77,7 +89,7 @@
                            "X-Ops-Content-Hash:~s\n"
                            "X-Ops-Timestamp:~s\n"
                            "X-Ops-UserId:~s",
-                           ["POST", ?hashed_path, ?hashed_body,
+                           ["POST", ?hashed_path_sha1, ?hashed_body_sha1,
                             ?request_time_iso8601, ?user]))).
 
 -define(expected_sign_string_v11,
@@ -86,7 +98,7 @@
                            "X-Ops-Content-Hash:~s\n"
                            "X-Ops-Timestamp:~s\n"
                            "X-Ops-UserId:~s",
-                           ["POST", ?hashed_path, ?hashed_body,
+                           ["POST", ?hashed_path_sha1, ?hashed_body_sha1,
                             ?request_time_iso8601, chef_authn:hash_string(?user)]))).
 
 -define(expected_sign_string_v12,
@@ -95,17 +107,33 @@
                            "X-Ops-Content-Hash:~s\n"
                            "X-Ops-Timestamp:~s\n"
                            "X-Ops-UserId:~s",
-                           ["POST", ?hashed_path, ?hashed_body,
+                           ["POST", ?hashed_path_sha1, ?hashed_body_sha1,
                             ?request_time_iso8601, chef_authn:hash_string(?user)]))).
 
--define(expected_sign_string_v13,
+-define(expected_sign_string_v13_sha1,
         iolist_to_binary(io_lib:format(
                            "Method:~s\nHashed Path:~s\n"
                            "X-Ops-Content-Hash:~s\n"
                            "X-Ops-Timestamp:~s\n"
                            "X-Ops-UserId:~s",
-                           ["POST", ?hashed_path, ?hashed_body,
-                            ?request_time_iso8601, chef_authn:hash_string(?user)]))).
+                           ["POST", ?hashed_path_sha1, ?hashed_body_sha1,
+                            ?request_time_iso8601,
+                            chef_authn:hash_string(?user,
+                                                   {?SIGNING_ALGORITHM_SHA1,
+                                                    ?SIGNING_VERSION_V1_3})]))).
+
+-define(expected_sign_string_v13_sha256,
+        iolist_to_binary(io_lib:format(
+                           "Method:~s\nHashed Path:~s\n"
+                           "X-Ops-Content-Hash:~s\n"
+                           "X-Ops-Timestamp:~s\n"
+                           "X-Ops-UserId:~s",
+                           ["POST", ?hashed_path_sha256, ?hashed_body_sha256,
+                            ?request_time_iso8601,
+                            chef_authn:hash_string(?user,
+                                                   {?SIGNING_ALGORITHM_SHA256,
+                                                    ?SIGNING_VERSION_V1_3})]))).
+
 
 
 canonical_path_test_() ->
@@ -122,24 +150,37 @@ canonical_path_test_() ->
     [ ?_assertEqual({P, Expect}, {P, chef_authn:canonical_path(P)})
       || {P, Expect} <- Tests ].
 
-hashed_path_test() ->
-    ?assertEqual(?hashed_path, chef_authn:hash_string(chef_authn:canonical_path(?path))).
+hashed_path_sha1_test() ->
+    ?assertEqual(?hashed_path_sha1, chef_authn:hash_string(chef_authn:canonical_path(?path))).
 
-hashed_path_query_params_are_ignored_test() ->
+hashed_path_sha1_query_params_are_ignored_test() ->
     %% for X-Ops_sign: version=1.0, query params are not included in
     %% the hash of the path for request verification.
-    ?assertEqual(?hashed_path, chef_authn:hash_string(chef_authn:canonical_path(?path_with_query))).
+    ?assertEqual(?hashed_path_sha1, chef_authn:hash_string(chef_authn:canonical_path(?path_with_query))).
 
 hashed_body_test() ->
-    ?assertEqual(?hashed_body, chef_authn:hashed_body(?body)),
+    TestCases = [
+                 {{?SIGNING_ALGORITHM_SHA1, ?SIGNING_VERSION_V1_0}, ?hashed_body_sha1},
+                 {{?SIGNING_ALGORITHM_SHA1, ?SIGNING_VERSION_V1_1}, ?hashed_body_sha1},
+                 {{?SIGNING_ALGORITHM_SHA1, ?SIGNING_VERSION_V1_2}, ?hashed_body_sha1},
+                 {{?SIGNING_ALGORITHM_SHA1, ?SIGNING_VERSION_V1_3}, ?hashed_body_sha1},
+                 {{?SIGNING_ALGORITHM_SHA256, ?SIGNING_VERSION_V1_3}, ?hashed_body_sha256}
+                ],
+    hashed_body_test_helper(TestCases).
+
+hashed_body_test_helper([]) ->
+    ok;
+hashed_body_test_helper([{SignInfo, ExpectedHash} | T]) ->
+    ?assertEqual(ExpectedHash, chef_authn:hashed_body(?body, SignInfo)),
     {ok, Fd} = file:open("../test/example_cert.pem", [read]),
-    FileHash = chef_authn:hashed_body(Fd),
+    FileHash = chef_authn:hashed_body(Fd, SignInfo),
     {ok, Bin} = file:read_file("../test/example_cert.pem"),
-    ContentHashFromBin = chef_authn:hashed_body(Bin),
-    ContentHashFromList = chef_authn:hashed_body(binary_to_list(Bin)),
+    ContentHashFromBin = chef_authn:hashed_body(Bin, SignInfo),
+    ContentHashFromList = chef_authn:hashed_body(binary_to_list(Bin), SignInfo),
     ?assert(is_binary(FileHash)),
     ?assertEqual(ContentHashFromBin, FileHash),
-    ?assertEqual(ContentHashFromList, FileHash).
+    ?assertEqual(ContentHashFromList, FileHash),
+    hashed_body_test_helper(T).
 
 signing_algorithm_test() ->
     ?assertEqual(<<"sha1">>, chef_authn:default_signing_algorithm()),
@@ -160,36 +201,36 @@ signing_version_test() ->
 canonicalize_request_v1_0_test() ->
     Algorithm = chef_authn:default_signing_algorithm(),
     Version = <<"1.0">>,
-    Val1 = chef_authn:canonicalize_request(?hashed_body, ?user, <<"post">>, ?request_time_iso8601, ?path,
+    Val1 = chef_authn:canonicalize_request(?hashed_body_sha1, ?user, <<"post">>, ?request_time_iso8601, ?path,
                                            Algorithm, Version),
     ?assertEqual(?expected_sign_string_v10, Val1),
 
     % verify normalization
-    Val2 = chef_authn:canonicalize_request(?hashed_body, ?user, <<"post">>, ?request_time_iso8601,
+    Val2 = chef_authn:canonicalize_request(?hashed_body_sha1, ?user, <<"post">>, ?request_time_iso8601,
                                 <<"/organizations/clownco/">>, Algorithm, Version),
     ?assertEqual(?expected_sign_string_v10, Val2).
 
 canonicalize_request_v_1_1_test() ->
     Algorithm = chef_authn:default_signing_algorithm(),
     Version = <<"1.1">>,
-    Val1 = chef_authn:canonicalize_request(?hashed_body, ?user, <<"post">>, ?request_time_iso8601, ?path,
+    Val1 = chef_authn:canonicalize_request(?hashed_body_sha1, ?user, <<"post">>, ?request_time_iso8601, ?path,
                                            Algorithm, Version),
     ?assertEqual(?expected_sign_string_v11, Val1),
 
     % verify normalization
-    Val2 = chef_authn:canonicalize_request(?hashed_body, ?user, <<"post">>, ?request_time_iso8601, ?path,
+    Val2 = chef_authn:canonicalize_request(?hashed_body_sha1, ?user, <<"post">>, ?request_time_iso8601, ?path,
                                 Algorithm, Version),
     ?assertEqual(?expected_sign_string_v11, Val2).
 
 canonicalize_request_v_1_2_test() ->
     Algorithm = chef_authn:default_signing_algorithm(),
     Version = <<"1.2">>,
-    Val1 = chef_authn:canonicalize_request(?hashed_body, ?user, <<"post">>, ?request_time_iso8601, ?path,
+    Val1 = chef_authn:canonicalize_request(?hashed_body_sha1, ?user, <<"post">>, ?request_time_iso8601, ?path,
                                            Algorithm, Version),
     ?assertEqual(?expected_sign_string_v12, Val1),
 
     % verify normalization
-    Val2 = chef_authn:canonicalize_request(?hashed_body, ?user, <<"post">>, ?request_time_iso8601, ?path,
+    Val2 = chef_authn:canonicalize_request(?hashed_body_sha1, ?user, <<"post">>, ?request_time_iso8601, ?path,
                                            Algorithm, Version),
     ?assertEqual(?expected_sign_string_v12, Val2).
 
@@ -304,9 +345,20 @@ verify_sig_v1_2_test() ->
                                        Public_key,
                                        {<<"sha1">>, <<"1.2">>})).
 
-verify_sig_v1_3_test() ->
-    Sig = iolist_to_binary(?X_OPS_AUTHORIZATION_LINES_V1_3),
-    Plain = ?expected_sign_string_v13,
+verify_sig_v1_3_sha1_test() ->
+    Sig = iolist_to_binary(?X_OPS_AUTHORIZATION_LINES_V1_3_SHA1),
+    Plain = ?expected_sign_string_v13_sha1,
+    {ok, Public_key} = file:read_file("test/example_cert.pem"),
+    ?assertEqual({name,<<"spec-user">>},
+                 chef_authn:verify_sig(Plain, ignore, ignore,
+                                       Sig,
+                                       list_to_binary(?X_OPS_USERID),
+                                       Public_key,
+                                       {<<"sha1">>, <<"1.3">>})).
+
+verify_sig_v1_3_sha256_test() ->
+    Sig = iolist_to_binary(?X_OPS_AUTHORIZATION_LINES_V1_3_SHA256),
+    Plain = ?expected_sign_string_v13_sha256,
     {ok, Public_key} = file:read_file("test/example_cert.pem"),
     ?assertEqual({name,<<"spec-user">>},
                  chef_authn:verify_sig(Plain, ignore, ignore,

--- a/test/chef_authn_tests.erl
+++ b/test/chef_authn_tests.erl
@@ -240,6 +240,32 @@ canonicalize_request_v_1_2_test() ->
                                            Algorithm, Version),
     ?assertEqual(?expected_sign_string_v12, Val2).
 
+canonicalize_request_v_1_3_sha1_test() ->
+    Algorithm = ?SIGNING_ALGORITHM_SHA1,
+    Version = <<"1.3">>,
+    Val1 = chef_authn:canonicalize_request(?hashed_body_sha1, ?user, <<"post">>, ?request_time_iso8601, ?path,
+                                           Algorithm, Version),
+    ?assertEqual(?expected_sign_string_v13_sha1, Val1),
+
+    % verify normalization
+    Val2 = chef_authn:canonicalize_request(?hashed_body_sha1, ?user, <<"post">>, ?request_time_iso8601, ?path,
+                                           Algorithm, Version),
+    ?assertEqual(?expected_sign_string_v13_sha1, Val2).
+
+canonicalize_request_v_1_3_sha256_test() ->
+    Algorithm = ?SIGNING_ALGORITHM_SHA256,
+    Version = <<"1.3">>,
+    Val1 = chef_authn:canonicalize_request(?hashed_body_sha256, ?user, <<"post">>, ?request_time_iso8601, ?path,
+                                           Algorithm, Version),
+    ?assertEqual(?expected_sign_string_v13_sha256, Val1),
+
+    % verify normalization
+    Val2 = chef_authn:canonicalize_request(?hashed_body_sha256, ?user, <<"post">>, ?request_time_iso8601, ?path,
+                                           Algorithm, Version),
+    ?assertEqual(?expected_sign_string_v13_sha256, Val2).
+
+
+
 sign_request_1_0_test() ->
     Algorithm = chef_authn:default_signing_algorithm(),
     Version = <<"1.0">>,


### PR DESCRIPTION
Here is the initial stab at signing version 1.3. v1.3 builds on top of v1.2 and adds support for specifying the algorithm to be used. Currently, the allowed algorithms are SHA1 and SHA256. In addition to this, there is a v1.3 of the signing format. Currently, it looks like:
```
Method:POST
Hashed Path:Z3EsTMw/UBNY9n+q+WBWTJmeVg8hQFbdFzVWRxW4dOA=
X-Ops-Content-Hash:hDlKNZhIhgso3Fs0S0pZwJ0xyBWtR1RBaeHs1DrzOho=
X-Ops-Sign:algorithm=sha256;version=1.3
X-Ops-Timestamp:2009-01-01T12:00:00Z
X-Ops-UserId:/pNOhczwdkQGXD4YAOBVm38wgq2WI7vKRk9d8WBhyKA=
```
Some notable changes here are that all the hashes in the format are now calculated as a function `HASH(alg, content)` where `alg` is the algorithm specified in `X-Ops-Sign`.

Some things that are still not done:
- Signing format v1.3 will include `X-Ops-Server-API-Version` for signing
- X-Ops-Sign will have an additional parameter `key` which will currently only allow `rsa`. While this shouldn't be necessary, it will provide a hint as to what keys to try in case we decide to implement something other than rsa.