### PR TITLE
Match changes requested in the RFC process for 1.3 signing

### DIFF
--- a/src/chef_authn.erl
+++ b/src/chef_authn.erl
@@ -108,7 +108,7 @@ default_signing_algorithm(SignVersion) ->
     case signing_protocols_for_version(SignVersion) of
         undefined ->
             {error, missing_version};
-        [Default|SupportedAlgorithms] ->
+        [Default|_SupportedAlgorithms] ->
             Default
     end.
 
@@ -555,7 +555,7 @@ validate_sign_description(GetHeader) ->
 -spec maybe_lookup_sign_algorithm(signing_algorithm() | default, signing_version()) -> signing_algorithm().
 maybe_lookup_sign_algorithm(default, SignVersion) ->
     default_signing_algorithm(SignVersion);
-maybe_lookup_sign_algorithm(SignAlgorithm, SignVersion) ->
+maybe_lookup_sign_algorithm(SignAlgorithm, _SignVersion) ->
     SignAlgorithm.
 
 %% @doc Determine if a request is valid

--- a/src/chef_authn.erl
+++ b/src/chef_authn.erl
@@ -325,21 +325,21 @@ canonicalize_request(BodyHash, UserId, Method, Time, Path, SignAlgorithm,
                      end
     end,
     iolist_to_binary(io_lib:format(Format, [canonical_method(Method),
-                                            hash_string(canonical_path(Path), {SignAlgorithm, SignVersion}),
+                                            canonical_path(Path),
                                             BodyHash,
-                                            SignAlgorithm, SignVersion,
+                                            SignVersion,
                                             Time,
                                             CanonicalUserId,
                                             ServerApiVersion])).
 
-
 canonicalize_userid(UserId, {_, SignVersion}=SignInfo)
   when SignVersion =:= ?SIGNING_VERSION_V1_1;
-       SignVersion =:= ?SIGNING_VERSION_V1_2;
-       SignVersion =:= ?SIGNING_VERSION_V1_3 ->
+       SignVersion =:= ?SIGNING_VERSION_V1_2 ->
             hash_string(UserId, SignInfo);
-canonicalize_userid(UserId, {_, ?SIGNING_VERSION_V1_0}) ->
-            UserId.
+canonicalize_userid(UserId, {_, SignVersion})
+  when SignVersion =:= ?SIGNING_VERSION_V1_0;
+       SignVersion =:= ?SIGNING_VERSION_V1_3 ->
+    UserId.
 
 -spec create_signature(binary(), public_key:rsa_private_key(),
                        {signing_algorithm(), signing_version()}) ->  binary().

--- a/src/chef_authn.hrl
+++ b/src/chef_authn.hrl
@@ -41,14 +41,6 @@
 %% we assume a default value.
 -define(DEFAULT_SERVER_API_VERSION, 0).
 
-%% This structure defines allowable hashing algorithms for each signing version.
-%% The frist one in the list is considered to be the default if none is
-%% specified
--define(SIGNING_VERSIONS, [{?SIGNING_VERSION_V1_0, [?SIGNING_ALGORITHM_SHA1]},
-                           {?SIGNING_VERSION_V1_1, [?SIGNING_ALGORITHM_SHA1]},
-                           {?SIGNING_VERSION_V1_2, [?SIGNING_ALGORITHM_SHA1]},
-                           {?SIGNING_VERSION_V1_3, [?SIGNING_ALGORITHM_SHA256]}]).
-
 -define(SIGNING_VERSION_KEY, <<"version">>).
 
 -define(SIGNING_ALGORITHM_KEY, <<"algorithm">>).

--- a/src/chef_authn.hrl
+++ b/src/chef_authn.hrl
@@ -41,7 +41,9 @@
 %% we assume a default value.
 -define(DEFAULT_SERVER_API_VERSION, 0).
 
-%% version 1.2 incorporates the related but slightly different RSA PKCS 1.5 SHA+RSA signing method
+%% This structure defines allowable hashing algorithms for each signing version.
+%% The frist one in the list is considered to be the default if none is
+%% specified
 -define(SIGNING_VERSIONS, [{?SIGNING_VERSION_V1_0, [?SIGNING_ALGORITHM_SHA1]},
                            {?SIGNING_VERSION_V1_1, [?SIGNING_ALGORITHM_SHA1]},
                            {?SIGNING_VERSION_V1_2, [?SIGNING_ALGORITHM_SHA1]},

--- a/src/chef_authn.hrl
+++ b/src/chef_authn.hrl
@@ -42,10 +42,11 @@
 -define(DEFAULT_SERVER_API_VERSION, 0).
 
 %% version 1.2 incorporates the related but slightly different RSA PKCS 1.5 SHA+RSA signing method
--define(SIGNING_VERSIONS, [?SIGNING_VERSION_V1_0,
-                           ?SIGNING_VERSION_V1_1,
-                           ?SIGNING_VERSION_V1_2,
-                           ?SIGNING_VERSION_V1_3]).
+-define(SIGNING_VERSIONS, [{?SIGNING_VERSION_V1_0, [?SIGNING_ALGORITHM_SHA1]},
+                           {?SIGNING_VERSION_V1_1, [?SIGNING_ALGORITHM_SHA1]},
+                           {?SIGNING_VERSION_V1_2, [?SIGNING_ALGORITHM_SHA1]},
+                           {?SIGNING_VERSION_V1_3, [?SIGNING_ALGORITHM_SHA1,
+                                                    ?SIGNING_ALGORITHM_SHA256]}]).
 
 -define(SIGNING_VERSION_KEY, <<"version">>).
 

--- a/src/chef_authn.hrl
+++ b/src/chef_authn.hrl
@@ -47,8 +47,7 @@
 -define(SIGNING_VERSIONS, [{?SIGNING_VERSION_V1_0, [?SIGNING_ALGORITHM_SHA1]},
                            {?SIGNING_VERSION_V1_1, [?SIGNING_ALGORITHM_SHA1]},
                            {?SIGNING_VERSION_V1_2, [?SIGNING_ALGORITHM_SHA1]},
-                           {?SIGNING_VERSION_V1_3, [?SIGNING_ALGORITHM_SHA1,
-                                                    ?SIGNING_ALGORITHM_SHA256]}]).
+                           {?SIGNING_VERSION_V1_3, [?SIGNING_ALGORITHM_SHA256]}]).
 
 -define(SIGNING_VERSION_KEY, <<"version">>).
 

--- a/src/chef_authn.hrl
+++ b/src/chef_authn.hrl
@@ -59,9 +59,9 @@
 
 %% The version 1.3 format includes the X-Ops-Sign and X-Ops-Server-API-Version
 %% headers. Thus, it will work only for Chef Server.
--define(VERSION1_3_SIG_FORMAT, <<"Method:~s\nHashed Path:~s\n"
+-define(VERSION1_3_SIG_FORMAT, <<"Method:~s\nPath:~s\n"
                                "X-Ops-Content-Hash:~s\n"
-                               "X-Ops-Sign:algorithm=~s;version=~s\n"
+                               "X-Ops-Sign:version=~s\n"
                                "X-Ops-Timestamp:~s\n"
                                "X-Ops-UserId:~s\n"
                                "X-Ops-Server-API-Version:~B">>).

--- a/test/chef_authn_tests.erl
+++ b/test/chef_authn_tests.erl
@@ -710,7 +710,6 @@ bad_signing_protocol_test() ->
     %% We convert here back into binary keys in headers since that
     %% is what we'd get when parsing the received headers over the wire
     Headers = [{list_to_binary(K), list_to_binary(V)} || {K, V} <- Headers0],
-    GetHeader = fun(X) -> proplists:get_value(X, Headers) end,
     % force time skew to allow a request to be processed 'now'
     TimeSkew = make_skew_time(),
 

--- a/test/chef_authn_tests.erl
+++ b/test/chef_authn_tests.erl
@@ -163,6 +163,34 @@
                             1
                            ]))).
 
+accepted_signing_protocol_test() ->
+    %% All signing versions should accept default
+    ?assertEqual(true, chef_authn:accepted_signing_protocol(default, ?SIGNING_VERSION_V1_0)),
+    ?assertEqual(true, chef_authn:accepted_signing_protocol(default, ?SIGNING_VERSION_V1_1)),
+    ?assertEqual(true, chef_authn:accepted_signing_protocol(default, ?SIGNING_VERSION_V1_2)),
+    ?assertEqual(true, chef_authn:accepted_signing_protocol(default, ?SIGNING_VERSION_V1_3)),
+
+    %% v1.0 supports only SHA1
+    ?assertEqual(true, chef_authn:accepted_signing_protocol(?SIGNING_ALGORITHM_SHA1, ?SIGNING_VERSION_V1_0)),
+    ?assertEqual(false, chef_authn:accepted_signing_protocol(?SIGNING_ALGORITHM_SHA256, ?SIGNING_VERSION_V1_0)),
+    ?assertEqual(false, chef_authn:accepted_signing_protocol(<<"foo">>, ?SIGNING_VERSION_V1_0)),
+
+    %% v1.1 supports only SHA1
+    ?assertEqual(true, chef_authn:accepted_signing_protocol(?SIGNING_ALGORITHM_SHA1, ?SIGNING_VERSION_V1_1)),
+    ?assertEqual(false, chef_authn:accepted_signing_protocol(?SIGNING_ALGORITHM_SHA256, ?SIGNING_VERSION_V1_1)),
+    ?assertEqual(false, chef_authn:accepted_signing_protocol(<<"foo">>, ?SIGNING_VERSION_V1_1)),
+
+    %% v1.2 supports only SHA1
+    ?assertEqual(true, chef_authn:accepted_signing_protocol(?SIGNING_ALGORITHM_SHA1, ?SIGNING_VERSION_V1_2)),
+    ?assertEqual(false, chef_authn:accepted_signing_protocol(?SIGNING_ALGORITHM_SHA256, ?SIGNING_VERSION_V1_2)),
+    ?assertEqual(false, chef_authn:accepted_signing_protocol(<<"foo">>, ?SIGNING_VERSION_V1_2)),
+
+    %% v1.3 supports SHA1 and SHA256
+    ?assertEqual(true, chef_authn:accepted_signing_protocol(?SIGNING_ALGORITHM_SHA1, ?SIGNING_VERSION_V1_3)),
+    ?assertEqual(true, chef_authn:accepted_signing_protocol(?SIGNING_ALGORITHM_SHA256, ?SIGNING_VERSION_V1_3)),
+    ?assertEqual(false, chef_authn:accepted_signing_protocol(<<"foo">>, ?SIGNING_VERSION_V1_3)).
+
+
 canonical_path_test_() ->
     Tests = [{<<"/">>, <<"/">>},
              {<<"////">>, <<"/">>},

--- a/test/chef_authn_tests.erl
+++ b/test/chef_authn_tests.erl
@@ -73,12 +73,12 @@
 
 -define(X_OPS_AUTHORIZATION_LINES_V1_3_SHA256,
         [
-         "BjR+iTK2eOgwmT2yGqLvE7Fp+VlpRGyL1dVoF2DmhUPO7EVsnxx2s32AmlOw",
-         "EpaACpav8SoB7K4rpOo3gfBm0XAYLnLLWzcec2OQG2O0wxxHiKVn4qWEe7Cs",
-         "RZ903DGM54t4uK75vx6wwoEdZqZe21npsLK+F3oAqnkgp+YXmlYv9Se5tFKB",
-         "0GWM1ibGJMjUIFAm7vxzjcuEvkkKN49MnXeMAAykfymcs74RU6xEKYzzSAyC",
-         "ygkV6xQSapDMp/aY29cVA/1FgZeVMhnFSTjtqBehchZYwXswr0A72A86gID9",
-         "h2QsUpmQJwbOK3bb1GptAnd5IiLzIxtu+vFeY6h4eA=="
+         "FZOmXAyOBAZQV/uw188iBljBJXOm+m8xQ/8KTGLkgGwZNcRFxk1m953XjE3W",
+         "VGy1dFT76KeaNWmPCNtDmprfH2na5UZFtfLIKrPv7xm80V+lzEzTd9WBwsfP",
+         "42dZ9N+V9I5SVfcL/lWrrlpdybfceJC5jOcP5tzfJXWUITwb6Z3Erg3DU3Uh",
+         "H9h9E0qWlYGqmiNCVrBnpe6Si1gU/Jl+rXlRSNbLJ4GlArAPuL976iTYJTzE",
+         "MmbLUIm3JRYi00Yb01IUCCKdI90vUq1HHNtlTEu93YZfQaJwRxXlGkCNwIJe",
+         "fy49QzaCIEu1XiOx5Jn+4GmkrZch/RrK9VzQWXgs+w=="
         ]
        ).
 
@@ -114,18 +114,15 @@
 
 -define(expected_sign_string_v13_sha256,
         iolist_to_binary(io_lib:format(
-                           "Method:~s\nHashed Path:~s\n"
+                           "Method:~s\nPath:~s\n"
                            "X-Ops-Content-Hash:~s\n"
-                           "X-Ops-Sign:algorithm=~s;version=~s\n"
+                           "X-Ops-Sign:version=1.3\n"
                            "X-Ops-Timestamp:~s\n"
                            "X-Ops-UserId:~s\n"
                            "X-Ops-Server-API-Version:~B",
-                           ["POST", ?hashed_path_sha256, ?hashed_body_sha256,
-                            ?SIGNING_ALGORITHM_SHA256, ?SIGNING_VERSION_V1_3,
+                           ["POST", ?path, ?hashed_body_sha256,
                             ?request_time_iso8601,
-                            chef_authn:hash_string(?user,
-                                                   {?SIGNING_ALGORITHM_SHA256,
-                                                    ?SIGNING_VERSION_V1_3}),
+                            ?user,
                             1
                            ]))).
 


### PR DESCRIPTION
The message format has been updated. We no longer hash user id and path. Hashing these things is no longer required. The reason they were hashing in v1.0/v1.1 is because the message was directly signed. This meant that there was a limit on the size of the message. v1.3 does not have this requirement as RSASSA-PKCS#1-v1_5 signs a hash of the message.