### PR TITLE
Fix `rsa_{private,public}_key` types

### DIFF
--- a/doc/chef_authn.md
+++ b/doc/chef_authn.md
@@ -6,34 +6,26 @@
 * [Function Index](#index)
 * [Function Details](#functions)
 
-
 chef_authn - Request signing and authentication for Opscode Chef.
+
 __Authors:__ Seth Falcon ([`seth@opscode.com`](mailto:seth@opscode.com)), Christopher Brown ([`cb@opscode.com`](mailto:cb@opscode.com)).
+
 <a name="description"></a>
 
 ## Description ##
-
-
 
 This module is an Erlang port of the mixlib-authentication Ruby gem.
 It can be used to sign HTTP requests to send to a Chef server or to
 validate such requests (for server implementation).
 
-
-
 Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
-
-
 
 This file is provided to you under the Apache License,
 Version 2.0 (the "License"); you may not use this file
 except in compliance with the License.  You may obtain
 a copy of the License at
 
-
-
 http://www.apache.org/licenses/LICENSE-2.0
-
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
@@ -52,7 +44,6 @@ under the License.
 ### <a name="type-base64_binary">base64_binary()</a> ###
 
 
-
 <pre><code>
 base64_binary() = &lt;&lt;_:64, _:_*8&gt;&gt;
 </code></pre>
@@ -60,9 +51,7 @@ base64_binary() = &lt;&lt;_:64, _:_*8&gt;&gt;
 
 
 
-
 ### <a name="type-get_header_fun">get_header_fun()</a> ###
-
 
 
 <pre><code>
@@ -72,23 +61,17 @@ get_header_fun() = fun((<a href="#type-header_name">header_name()</a>) -&gt; <a 
 
 
 
-
 ### <a name="type-header_fun">header_fun()</a> ###
 
 
-
 <pre><code>
-header_fun() = fun((<a href="#type-header_name">header_name()</a>) -&gt; <a href="#type-header_value">header_value()</a>)
+header_fun() = undefined | fun((<a href="#type-header_name">header_name()</a>) -&gt; <a href="#type-header_value">header_value()</a>)
 </code></pre>
 
 
 
-  -type rsa_public_key() :: public_key:rsa_public_key().
-
-
 
 ### <a name="type-header_name">header_name()</a> ###
-
 
 
 <pre><code>
@@ -98,9 +81,7 @@ header_name() = binary()
 
 
 
-
 ### <a name="type-header_value">header_value()</a> ###
-
 
 
 <pre><code>
@@ -110,9 +91,7 @@ header_value() = binary() | undefined
 
 
 
-
 ### <a name="type-http_body">http_body()</a> ###
-
 
 
 <pre><code>
@@ -122,9 +101,7 @@ http_body() = binary() | pid()
 
 
 
-
 ### <a name="type-http_method">http_method()</a> ###
-
 
 
 <pre><code>
@@ -134,9 +111,7 @@ http_method() = binary()
 
 
 
-
 ### <a name="type-http_path">http_path()</a> ###
-
 
 
 <pre><code>
@@ -146,9 +121,17 @@ http_path() = binary()
 
 
 
+### <a name="type-key_desc">key_desc()</a> ###
+
+
+<pre><code>
+key_desc() = any()
+</code></pre>
+
+
+
 
 ### <a name="type-public_key_data">public_key_data()</a> ###
-
 
 
 <pre><code>
@@ -158,9 +141,27 @@ public_key_data() = {cert, <a href="#type-base64_binary">base64_binary()</a>} | 
 
 
 
+### <a name="type-rsa_private_key">rsa_private_key()</a> ###
+
+
+<pre><code>
+rsa_private_key() = #'RSAPrivateKey'{}
+</code></pre>
+
+
+
+
+### <a name="type-rsa_public_key">rsa_public_key()</a> ###
+
+
+<pre><code>
+rsa_public_key() = #'RSAPublicKey'{}
+</code></pre>
+
+
+
 
 ### <a name="type-sha_hash64">sha_hash64()</a> ###
-
 
 
 <pre><code>
@@ -170,9 +171,17 @@ sha_hash64() = binary()
 
 
 
+### <a name="type-sign_parameter">sign_parameter()</a> ###
+
+
+<pre><code>
+sign_parameter() = {private_key, <a href="#type-rsa_private_key">rsa_private_key()</a>} | {body, <a href="#type-http_body">http_body()</a>} | {user, <a href="#type-user_id">user_id()</a>} | {method, <a href="#type-http_method">http_method()</a>} | {time, <a href="#type-erlang_time">erlang_time()</a> | now} | {path, <a href="#type-http_path">http_path()</a>} | {get_header, <a href="#type-header_fun">header_fun()</a>}
+</code></pre>
+
+
+
 
 ### <a name="type-signing_algorithm">signing_algorithm()</a> ###
-
 
 
 <pre><code>
@@ -182,9 +191,7 @@ signing_algorithm() = &lt;&lt;_:32&gt;&gt;
 
 
 
-
 ### <a name="type-signing_version">signing_version()</a> ###
-
 
 
 <pre><code>
@@ -194,24 +201,22 @@ signing_version() = &lt;&lt;_:24&gt;&gt;
 
 
 
-
 ### <a name="type-user_id">user_id()</a> ###
-
 
 
 <pre><code>
 user_id() = binary()
 </code></pre>
 
-
 <a name="index"></a>
 
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#accepted_signing_algorithm-1">accepted_signing_algorithm/1</a></td><td>Is the signing algorithm valid?
-of {unknown_algorithm, Algorithm}.</td></tr><tr><td valign="top"><a href="#accepted_signing_version-1">accepted_signing_version/1</a></td><td>Is the signing version acceptable for chef request.</td></tr><tr><td valign="top"><a href="#authenticate_user_request-6">authenticate_user_request/6</a></td><td>Determine if a request is valid.</td></tr><tr><td valign="top"><a href="#default_signing_algorithm-0">default_signing_algorithm/0</a></td><td>Return the default signing algorithm.</td></tr><tr><td valign="top"><a href="#default_signing_version-0">default_signing_version/0</a></td><td>Return the default signing version.</td></tr><tr><td valign="top"><a href="#extract_private_key-1">extract_private_key/1</a></td><td></td></tr><tr><td valign="top"><a href="#extract_public_key-1">extract_public_key/1</a></td><td></td></tr><tr><td valign="top"><a href="#extract_public_or_private_key-1">extract_public_or_private_key/1</a></td><td>Given PEM content as binary, return either an RSA public or private key record (or
-error tuple).</td></tr><tr><td valign="top"><a href="#hash_file-1">hash_file/1</a></td><td>Base 64 encoded SHA1 of contents of <code>F</code>, which must be the pid of a file.</td></tr><tr><td valign="top"><a href="#hash_string-1">hash_string/1</a></td><td>Base 64 encoded SHA1 of <code>Str</code></td></tr><tr><td valign="top"><a href="#sign_request-5">sign_request/5</a></td><td>Sign an HTTP request without a body (primarily GET).</td></tr><tr><td valign="top"><a href="#sign_request-6">sign_request/6</a></td><td></td></tr><tr><td valign="top"><a href="#sign_request-8">sign_request/8</a></td><td>Sign an HTTP request so it can be sent to a Chef server.</td></tr><tr><td valign="top"><a href="#validate_headers-2">validate_headers/2</a></td><td>Validate that all required headers are present.</td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#accepted_signing_algorithm-1">accepted_signing_algorithm/1</a></td><td>(<em>Deprecated</em>.) Is the signing algorithm valid?
+of {unknown_algorithm, Algorithm}.</td></tr><tr><td valign="top"><a href="#accepted_signing_protocol-2">accepted_signing_protocol/2</a></td><td>Is the signing version and algorithm acceptable for chef request.</td></tr><tr><td valign="top"><a href="#accepted_signing_version-1">accepted_signing_version/1</a></td><td>Is the signing version acceptable for chef request.</td></tr><tr><td valign="top"><a href="#authenticate_user_request-6">authenticate_user_request/6</a></td><td>Determine if a request is valid.</td></tr><tr><td valign="top"><a href="#default_signing_algorithm-0">default_signing_algorithm/0</a></td><td>(<em>Deprecated</em>.) Return the default signing algorithm.</td></tr><tr><td valign="top"><a href="#default_signing_algorithm-1">default_signing_algorithm/1</a></td><td>Return the default signing algorithm for the specified Version.</td></tr><tr><td valign="top"><a href="#default_signing_version-0">default_signing_version/0</a></td><td>Return the default signing version.</td></tr><tr><td valign="top"><a href="#extract_pem_encoded_public_key-1">extract_pem_encoded_public_key/1</a></td><td>Given PEM X509 certificate as a binary, return the RSA public key
+in PEM format.</td></tr><tr><td valign="top"><a href="#extract_private_key-1">extract_private_key/1</a></td><td></td></tr><tr><td valign="top"><a href="#extract_public_key-1">extract_public_key/1</a></td><td></td></tr><tr><td valign="top"><a href="#extract_public_or_private_key-1">extract_public_or_private_key/1</a></td><td>Given PEM content as binary, return either an RSA public or private key record (or
+error tuple).</td></tr><tr><td valign="top"><a href="#hash_file-1">hash_file/1</a></td><td>(<em>Deprecated</em>.) Base 64 encoded SHA1 of contents of <code>F</code>, which must be the pid of a file.</td></tr><tr><td valign="top"><a href="#hash_string-1">hash_string/1</a></td><td>(<em>Deprecated</em>.) Base 64 encoded SHA1 of <code>Str</code></td></tr><tr><td valign="top"><a href="#sign_request-2">sign_request/2</a></td><td>Sign an HTTP request so it can be sent to a Chef server.</td></tr><tr><td valign="top"><a href="#sign_request-5">sign_request/5</a></td><td>(<em>Deprecated</em>.) Sign an HTTP request without a body (primarily GET).</td></tr><tr><td valign="top"><a href="#sign_request-6">sign_request/6</a></td><td>(<em>Deprecated</em>.) Sign an HTTP request without a body (primarily GET).</td></tr><tr><td valign="top"><a href="#sign_request-8">sign_request/8</a></td><td>(<em>Deprecated</em>.) Sign an HTTP request so it can be sent to a Chef server.</td></tr><tr><td valign="top"><a href="#validate_headers-2">validate_headers/2</a></td><td>Validate that all required headers are present.</td></tr></table>
 
 
 <a name="functions"></a>
@@ -222,56 +227,56 @@ error tuple).</td></tr><tr><td valign="top"><a href="#hash_file-1">hash_file/1</
 
 ### accepted_signing_algorithm/1 ###
 
-
 <pre><code>
 accepted_signing_algorithm(Algorithm::binary()) -&gt; boolean()
 </code></pre>
+<br />
 
-<br></br>
-
+__This function is deprecated:__ use accepted_signing_protocol/2 instead
 
 Is the signing algorithm valid?
 of {unknown_algorithm, Algorithm}
+
+<a name="accepted_signing_protocol-2"></a>
+
+### accepted_signing_protocol/2 ###
+
+<pre><code>
+accepted_signing_protocol(SignAlgorithm::binary() | default, SignVersion::binary()) -&gt; boolean()
+</code></pre>
+<br />
+
+Is the signing version and algorithm acceptable for chef request.  Returns true if so, else false.
+
 <a name="accepted_signing_version-1"></a>
 
 ### accepted_signing_version/1 ###
 
-
 <pre><code>
-accepted_signing_version(Version::binary()) -&gt; boolean()
+accepted_signing_version(SignVersion::binary()) -&gt; boolean()
 </code></pre>
-
-<br></br>
-
+<br />
 
 Is the signing version acceptable for chef request.  Returns true if so, else false.
+
 <a name="authenticate_user_request-6"></a>
 
 ### authenticate_user_request/6 ###
 
-
 <pre><code>
-authenticate_user_request(GetHeader::<a href="#type-get_header_fun">get_header_fun()</a>, Method::<a href="#type-http_method">http_method()</a>, Path::<a href="#type-http_path">http_path()</a>, Body::<a href="#type-http_body">http_body()</a>, PublicKey::<a href="#type-public_key_data">public_key_data()</a> | <a href="#type-rsa_public_key">rsa_public_key()</a>, TimeSkew::<a href="#type-time_skew">time_skew()</a>) -&gt; {name, <a href="#type-user_id">user_id()</a>} | {no_authn, Reason::term()}
+authenticate_user_request(GetHeader::<a href="#type-get_header_fun">get_header_fun()</a>, Method::<a href="#type-http_method">http_method()</a>, Path::<a href="#type-http_path">http_path()</a>, Body::<a href="#type-http_body">http_body()</a>, PublicKey::<a href="#type-public_key_data">public_key_data()</a> | <a href="#type-rsa_public_key">rsa_public_key()</a>, TimeSkew::<a href="#type-time_skew">time_skew()</a>) -&gt; {name, <a href="#type-user_id">user_id()</a>} | {name, <a href="#type-user_id">user_id()</a>, <a href="#type-key_desc">key_desc()</a>} | {no_authn, Reason::term()}
 </code></pre>
-
-<br></br>
-
-
+<br />
 
 Determine if a request is valid
-
-
 
 The `GetHeader` argument is a fun that closes over the request
 headers and can be called to obtain the value of a header.  It
 should either return the value of the header as binary or
 'undefined'.
 
-
-
 A request signed with a timestamp more than `TimeSkew` seconds from
 now will not be authenticated.
-
 
 `PublicKey` is a binary containing an RSA public key in PEM format.
 
@@ -279,168 +284,181 @@ now will not be authenticated.
 
 ### default_signing_algorithm/0 ###
 
-
 <pre><code>
 default_signing_algorithm() -&gt; <a href="#type-signing_algorithm">signing_algorithm()</a>
 </code></pre>
+<br />
 
-<br></br>
-
+__This function is deprecated:__ use default_signing_algorithm/1
 
 Return the default signing algorithm
+
+<a name="default_signing_algorithm-1"></a>
+
+### default_signing_algorithm/1 ###
+
+<pre><code>
+default_signing_algorithm(SignVersion::binary()) -&gt; <a href="#type-signing_algorithm">signing_algorithm()</a> | {error, missing_version}
+</code></pre>
+<br />
+
+Return the default signing algorithm for the specified Version
+
 <a name="default_signing_version-0"></a>
 
 ### default_signing_version/0 ###
 
-
 <pre><code>
 default_signing_version() -&gt; <a href="#type-signing_version">signing_version()</a>
 </code></pre>
-
-<br></br>
-
+<br />
 
 Return the default signing version
+
+<a name="extract_pem_encoded_public_key-1"></a>
+
+### extract_pem_encoded_public_key/1 ###
+
+<pre><code>
+extract_pem_encoded_public_key(RawCert::binary()) -&gt; binary() | {error, bad_key}
+</code></pre>
+<br />
+
+Given PEM X509 certificate as a binary, return the RSA public key
+in PEM format. If the argument is not a certificate, bad_key will be returned.
+
 <a name="extract_private_key-1"></a>
 
 ### extract_private_key/1 ###
 
-
 <pre><code>
-extract_private_key(RawKey::binary()) -&gt; #'RSAPrivateKey'{} | {error, bad_key}
+extract_private_key(RawKey::binary()) -&gt; <a href="#type-rsa_private_key">rsa_private_key()</a> | {error, bad_key}
 </code></pre>
-
-<br></br>
-
-
+<br />
 
 <a name="extract_public_key-1"></a>
 
 ### extract_public_key/1 ###
 
-
 <pre><code>
-extract_public_key(RawKey::binary()) -&gt; #'RSAPublicKey'{} | {error, bad_key}
+extract_public_key(RawKey::binary()) -&gt; <a href="#type-rsa_public_key">rsa_public_key()</a> | {error, bad_key}
 </code></pre>
-
-<br></br>
-
-
+<br />
 
 <a name="extract_public_or_private_key-1"></a>
 
 ### extract_public_or_private_key/1 ###
 
-
 <pre><code>
-extract_public_or_private_key(RawKey::binary()) -&gt; #'RSAPublicKey'{} | #'RSAPrivateKey'{} | {error, bad_key}
+extract_public_or_private_key(RawKey::binary()) -&gt; <a href="#type-rsa_public_key">rsa_public_key()</a> | <a href="#type-rsa_private_key">rsa_private_key()</a> | {error, bad_key}
 </code></pre>
-
-<br></br>
-
+<br />
 
 Given PEM content as binary, return either an RSA public or private key record (or
 error tuple). The PEM can contain an RSA public key in PKCS1, SPKI (X509), or an X509
 certificate wrapping an SPKI formatted key. Note that private keys will not be extracted
 from X509 certificate data.
+
 <a name="hash_file-1"></a>
 
 ### hash_file/1 ###
 
-
 <pre><code>
 hash_file(F::pid()) -&gt; <a href="#type-sha_hash64">sha_hash64()</a>
 </code></pre>
+<br />
 
-<br></br>
-
+__This function is deprecated:__ This is an internal function and stop being exposed
 
 Base 64 encoded SHA1 of contents of `F`, which must be the pid of a file
+
 <a name="hash_string-1"></a>
 
 ### hash_string/1 ###
 
-
 <pre><code>
 hash_string(Str::string() | binary()) -&gt; <a href="#type-sha_hash64">sha_hash64()</a>
 </code></pre>
+<br />
 
-<br></br>
-
+__This function is deprecated:__ This is an internal function
 
 Base 64 encoded SHA1 of `Str`
+
+<a name="sign_request-2"></a>
+
+### sign_request/2 ###
+
+<pre><code>
+sign_request(SignInfo::{<a href="#type-signing_algorithm">signing_algorithm()</a>, <a href="#type-signing_version">signing_version()</a>}, Options::[<a href="#type-sign_parameter">sign_parameter()</a>]) -&gt; [{[any()], [any()]}]
+</code></pre>
+<br />
+
+Sign an HTTP request so it can be sent to a Chef server.
+
+Returns a list of header tuples that should be included in the
+final HTTP request.
+
 <a name="sign_request-5"></a>
 
 ### sign_request/5 ###
 
-
 <pre><code>
 sign_request(PrivateKey::<a href="#type-rsa_private_key">rsa_private_key()</a>, User::<a href="#type-user_id">user_id()</a>, Method::<a href="#type-http_method">http_method()</a>, Time::<a href="#type-erlang_time">erlang_time()</a> | now, Path::<a href="#type-http_path">http_path()</a>) -&gt; [{[any()], [any()]}]
 </code></pre>
+<br />
 
-<br></br>
-
+__This function is deprecated:__ Use sign_request/2 instead.
 
 Sign an HTTP request without a body (primarily GET)
+
 <a name="sign_request-6"></a>
 
 ### sign_request/6 ###
 
-
 <pre><code>
 sign_request(PrivateKey::<a href="#type-rsa_private_key">rsa_private_key()</a>, Body::<a href="#type-http_body">http_body()</a>, User::<a href="#type-user_id">user_id()</a>, Method::<a href="#type-http_method">http_method()</a>, Time::<a href="#type-erlang_time">erlang_time()</a> | now, Path::<a href="#type-http_path">http_path()</a>) -&gt; [{[any()], [any()]}]
 </code></pre>
+<br />
 
-<br></br>
+__This function is deprecated:__ Use sign_request/2 instead.
 
-
+Sign an HTTP request without a body (primarily GET)
 
 <a name="sign_request-8"></a>
 
 ### sign_request/8 ###
 
-
 <pre><code>
 sign_request(PrivateKey::<a href="#type-rsa_private_key">rsa_private_key()</a>, Body::<a href="#type-http_body">http_body()</a>, User::<a href="#type-user_id">user_id()</a>, Method::<a href="#type-http_method">http_method()</a>, Time::<a href="#type-erlang_time">erlang_time()</a> | now, Path::<a href="#type-http_path">http_path()</a>, SignAlgorithm::<a href="#type-signing_algorithm">signing_algorithm()</a>, SignVersion::<a href="#type-signing_version">signing_version()</a>) -&gt; [{[any()], [any()]}]
 </code></pre>
+<br />
 
-<br></br>
-
-
+__This function is deprecated:__ Use sign_request/2 instead.
 
 Sign an HTTP request so it can be sent to a Chef server.
-
-
 
 Returns a list of header tuples that should be included in the
 final HTTP request.
 
-
-
 The keys are returned as strings to match with what is required by ibrowse. The values
 are returned as binary().
 
-
 Note that the headers can't be passed directly to validate_headers which expects headers to
 have binary keys (as returned from the ejson/jiffy parsing routines
+
 <a name="validate_headers-2"></a>
 
 ### validate_headers/2 ###
 
-
 <pre><code>
 validate_headers(GetHeader::<a href="#type-header_fun">header_fun()</a>, TimeSkew::<a href="#type-time_skew">time_skew()</a>) -&gt; [{algorithm, binary()} | {version, binary()}, ...]
 </code></pre>
-
-<br></br>
-
+<br />
 
 throws `{missing, [binary()]} | bad_clock | bad_sign_desc`
 
-
-
 Validate that all required headers are present
-
 
 Returns 'ok' if all required headers are present.  Otherwise, throws
 `{missing, [header_name()]}` providing a list of the

--- a/doc/chef_keygen_cache.md
+++ b/doc/chef_keygen_cache.md
@@ -5,20 +5,18 @@
 * [Function Index](#index)
 * [Function Details](#functions)
 
-
 chef_keygen_cache Precreates RSA key pairs and servers them when you ask.
+
 __Behaviours:__ [`gen_server`](gen_server.md).
+
 <a name="description"></a>
 
 ## Description ##
-
-
 
 chef_keygen_cache is a gen_server that keeps a configurable number of RSA key pairs on
 hand for fast delivery. You can configure how many workers are used to replinish the key
 cache when it drops below the desired size. If you request a key when the cache is empty,
 the atom `keygen_timeout` is returned immediately.
-
 
 You can control the behavior of the key cache using the following app config keys:
 
@@ -45,7 +43,7 @@ to speed up testing.
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#code_change-3">code_change/3</a></td><td></td></tr><tr><td valign="top"><a href="#get_key_pair-0">get_key_pair/0</a></td><td>Retrieve an RSA key pair from the cache.</td></tr><tr><td valign="top"><a href="#handle_call-3">handle_call/3</a></td><td></td></tr><tr><td valign="top"><a href="#handle_cast-2">handle_cast/2</a></td><td></td></tr><tr><td valign="top"><a href="#handle_info-2">handle_info/2</a></td><td></td></tr><tr><td valign="top"><a href="#init-1">init/1</a></td><td></td></tr><tr><td valign="top"><a href="#start_link-0">start_link/0</a></td><td></td></tr><tr><td valign="top"><a href="#status-0">status/0</a></td><td>Return a proplist of status information about the state of the key cache.</td></tr><tr><td valign="top"><a href="#stop-0">stop/0</a></td><td></td></tr><tr><td valign="top"><a href="#terminate-2">terminate/2</a></td><td></td></tr><tr><td valign="top"><a href="#update_config-0">update_config/0</a></td><td>Instruct the cache to reread app config values.</td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#code_change-3">code_change/3</a></td><td></td></tr><tr><td valign="top"><a href="#get_key_pair-0">get_key_pair/0</a></td><td>Retrieve an RSA key pair from the cache.</td></tr><tr><td valign="top"><a href="#handle_call-3">handle_call/3</a></td><td></td></tr><tr><td valign="top"><a href="#handle_cast-2">handle_cast/2</a></td><td></td></tr><tr><td valign="top"><a href="#handle_info-2">handle_info/2</a></td><td></td></tr><tr><td valign="top"><a href="#init-1">init/1</a></td><td></td></tr><tr><td valign="top"><a href="#start_link-0">start_link/0</a></td><td></td></tr><tr><td valign="top"><a href="#status-0">status/0</a></td><td>Return a proplist of status information about the state of the key cache.</td></tr><tr><td valign="top"><a href="#status_for_json-0">status_for_json/0</a></td><td></td></tr><tr><td valign="top"><a href="#stop-0">stop/0</a></td><td></td></tr><tr><td valign="top"><a href="#terminate-2">terminate/2</a></td><td></td></tr><tr><td valign="top"><a href="#update_config-0">update_config/0</a></td><td>Instruct the cache to reread app config values.</td></tr></table>
 
 
 <a name="functions"></a>
@@ -58,33 +56,27 @@ to speed up testing.
 
 `code_change(OldVsn, State, Extra) -> any()`
 
-
 <a name="get_key_pair-0"></a>
 
 ### get_key_pair/0 ###
 
-
 <pre><code>
 get_key_pair() -&gt; {PublicKey::binary(), PrivateKey::binary()} | keygen_timeout
 </code></pre>
-
-<br></br>
-
-
+<br />
 
 Retrieve an RSA key pair from the cache.
-
 
 The return value is a tuple of the form `{PublicKey, PrivateKey}` where each element is a
 binary containing the PEM encoded key. If no keys are available in the cache or if the
 cache takes longer than the timeout value specified in app config `{chef_authn,
 kegen_timeout, Timeout}`, then the atom `keygen_timeout` is returned.
+
 <a name="handle_call-3"></a>
 
 ### handle_call/3 ###
 
 `handle_call(Request, From, State) -> any()`
-
 
 <a name="handle_cast-2"></a>
 
@@ -92,13 +84,11 @@ kegen_timeout, Timeout}`, then the atom `keygen_timeout` is returned.
 
 `handle_cast(Request, State) -> any()`
 
-
 <a name="handle_info-2"></a>
 
 ### handle_info/2 ###
 
 `handle_info(Key_pair, State) -> any()`
-
 
 <a name="init-1"></a>
 
@@ -106,33 +96,34 @@ kegen_timeout, Timeout}`, then the atom `keygen_timeout` is returned.
 
 `init(X1) -> any()`
 
-
 <a name="start_link-0"></a>
 
 ### start_link/0 ###
 
 `start_link() -> any()`
 
-
 <a name="status-0"></a>
 
 ### status/0 ###
 
-
 <pre><code>
 status() -&gt; [{atom(), term()}]
 </code></pre>
-
-<br></br>
-
+<br />
 
 Return a proplist of status information about the state of the key cache.
+
+<a name="status_for_json-0"></a>
+
+### status_for_json/0 ###
+
+`status_for_json() -> any()`
+
 <a name="stop-0"></a>
 
 ### stop/0 ###
 
 `stop() -> any()`
-
 
 <a name="terminate-2"></a>
 
@@ -140,17 +131,13 @@ Return a proplist of status information about the state of the key cache.
 
 `terminate(Reason, State) -> any()`
 
-
 <a name="update_config-0"></a>
 
 ### update_config/0 ###
 
-
 <pre><code>
 update_config() -&gt; ok
 </code></pre>
-
-<br></br>
-
+<br />
 
 Instruct the cache to reread app config values.

--- a/doc/chef_keygen_worker.md
+++ b/doc/chef_keygen_worker.md
@@ -5,20 +5,17 @@
 * [Function Index](#index)
 * [Function Details](#functions)
 
-
 chef_keygen_worker makes RSA key pairs just for you.
+
 __Behaviours:__ [`gen_server`](gen_server.md).
+
 <a name="description"></a>
 
 ## Description ##
 
-
-
 chef_keygen_worker is a single-use worker gen_server. When started, it generates an RSA
 key pair and stores it in server state. Calling [`get_key_pair/1`](#get_key_pair-1) will return the
 generated key pair and terminate the worker.
-
-
 
 Instead of relying on NIFs and correct use of libopenssl, this code shells out to openssl
 to generate a private key and then uses functions in the public_key module to extract and
@@ -26,14 +23,12 @@ encode the public key. The call to the openssl command line utility is done via 
 and requires message passing. For this reason, the call is made inside init to avoid
 issues from misuse of this single key pair worker.
 
-
 Basic use is:
 
 ```
   {ok, Pid} = chef_keygen_worker:start_link(),
   #key_pair{public_key = Pub, private_key = Priv} = chef_keygen_worker:get_key_pair(Pid)
 ```
-
 
 There are two app config keys you can use to control the behavior of this worker. The key
 `keygen_size` determines the RSA key size in bits to generate. If not specified, the
@@ -60,19 +55,14 @@ instead of a key. Both values are read from app config on each invocation.
 
 `code_change(OldVsn, State, Extra) -> any()`
 
-
 <a name="get_key_pair-1"></a>
 
 ### get_key_pair/1 ###
 
-
 <pre><code>
 get_key_pair(Pid::pid()) -&gt; #key_pair{} | keygen_timeout
 </code></pre>
-
-<br></br>
-
-
+<br />
 
 <a name="handle_call-3"></a>
 
@@ -80,13 +70,11 @@ get_key_pair(Pid::pid()) -&gt; #key_pair{} | keygen_timeout
 
 `handle_call(Request, From, KeyPair) -> any()`
 
-
 <a name="handle_cast-2"></a>
 
 ### handle_cast/2 ###
 
 `handle_cast(Request, State) -> any()`
-
 
 <a name="handle_info-2"></a>
 
@@ -94,13 +82,11 @@ get_key_pair(Pid::pid()) -&gt; #key_pair{} | keygen_timeout
 
 `handle_info(Info, State) -> any()`
 
-
 <a name="init-1"></a>
 
 ### init/1 ###
 
 `init(X1) -> any()`
-
 
 <a name="start_link-1"></a>
 
@@ -108,11 +94,9 @@ get_key_pair(Pid::pid()) -&gt; #key_pair{} | keygen_timeout
 
 `start_link(Config) -> any()`
 
-
 <a name="terminate-2"></a>
 
 ### terminate/2 ###
 
 `terminate(Reason, State) -> any()`
-
 

--- a/doc/chef_keygen_worker_sup.md
+++ b/doc/chef_keygen_worker_sup.md
@@ -5,14 +5,13 @@
 * [Function Index](#index)
 * [Function Details](#functions)
 
-
 supervisor for chef_keygen_worker throw-away key generator processs.
+
 __Behaviours:__ [`supervisor`](supervisor.md).
+
 <a name="description"></a>
 
 ## Description ##
-
-
 Example:
 
 ```
@@ -21,17 +20,24 @@ Example:
   chef_keygen_worker:get_key_pair(Pid).
 ```
 
+The app config key openssl_path allows the default command to be overridden
 <a name="index"></a>
 
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#init-1">init/1</a></td><td></td></tr><tr><td valign="top"><a href="#new_worker-0">new_worker/0</a></td><td></td></tr><tr><td valign="top"><a href="#new_worker-1">new_worker/1</a></td><td></td></tr><tr><td valign="top"><a href="#start_link-0">start_link/0</a></td><td></td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#get_openssl-0">get_openssl/0</a></td><td></td></tr><tr><td valign="top"><a href="#init-1">init/1</a></td><td></td></tr><tr><td valign="top"><a href="#new_worker-0">new_worker/0</a></td><td></td></tr><tr><td valign="top"><a href="#new_worker-1">new_worker/1</a></td><td></td></tr><tr><td valign="top"><a href="#start_link-0">start_link/0</a></td><td></td></tr></table>
 
 
 <a name="functions"></a>
 
 ## Function Details ##
+
+<a name="get_openssl-0"></a>
+
+### get_openssl/0 ###
+
+`get_openssl() -> any()`
 
 <a name="init-1"></a>
 
@@ -39,13 +45,11 @@ Example:
 
 `init(X1) -> any()`
 
-
 <a name="new_worker-0"></a>
 
 ### new_worker/0 ###
 
 `new_worker() -> any()`
-
 
 <a name="new_worker-1"></a>
 
@@ -53,11 +57,9 @@ Example:
 
 `new_worker(Pid) -> any()`
 
-
 <a name="start_link-0"></a>
 
 ### start_link/0 ###
 
 `start_link() -> any()`
-
 

--- a/doc/chef_keyring.md
+++ b/doc/chef_keyring.md
@@ -21,10 +21,10 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 
-
 __Behaviours:__ [`gen_server`](gen_server.md).
 
 __Authors:__ Kevin Smith ([`kevin@opscode.com`](mailto:kevin@opscode.com)), Mark Anderson ([`mark@opscode.com`](mailto:mark@opscode.com)).
+
 <a name="index"></a>
 
 ## Function Index ##
@@ -43,13 +43,11 @@ __Authors:__ Kevin Smith ([`kevin@opscode.com`](mailto:kevin@opscode.com)), Mark
 
 `code_change(OldVsn, State, Extra) -> any()`
 
-
 <a name="get_key-1"></a>
 
 ### get_key/1 ###
 
 `get_key(KeyName) -> any()`
-
 
 <a name="handle_call-3"></a>
 
@@ -57,13 +55,11 @@ __Authors:__ Kevin Smith ([`kevin@opscode.com`](mailto:kevin@opscode.com)), Mark
 
 `handle_call(Request, From, State) -> any()`
 
-
 <a name="handle_cast-2"></a>
 
 ### handle_cast/2 ###
 
 `handle_cast(Request, State) -> any()`
-
 
 <a name="handle_info-2"></a>
 
@@ -71,13 +67,11 @@ __Authors:__ Kevin Smith ([`kevin@opscode.com`](mailto:kevin@opscode.com)), Mark
 
 `handle_info(Info, State) -> any()`
 
-
 <a name="init-1"></a>
 
 ### init/1 ###
 
 `init(X1) -> any()`
-
 
 <a name="list_keys-0"></a>
 
@@ -85,13 +79,11 @@ __Authors:__ Kevin Smith ([`kevin@opscode.com`](mailto:kevin@opscode.com)), Mark
 
 `list_keys() -> any()`
 
-
 <a name="reload-0"></a>
 
 ### reload/0 ###
 
 `reload() -> any()`
-
 
 <a name="reload_if_changed-0"></a>
 
@@ -99,13 +91,11 @@ __Authors:__ Kevin Smith ([`kevin@opscode.com`](mailto:kevin@opscode.com)), Mark
 
 `reload_if_changed() -> any()`
 
-
 <a name="start_link-0"></a>
 
 ### start_link/0 ###
 
 `start_link() -> any()`
-
 
 <a name="stats-0"></a>
 
@@ -113,11 +103,9 @@ __Authors:__ Kevin Smith ([`kevin@opscode.com`](mailto:kevin@opscode.com)), Mark
 
 `stats() -> any()`
 
-
 <a name="terminate-2"></a>
 
 ### terminate/2 ###
 
 `terminate(Reason, State) -> any()`
-
 

--- a/doc/chef_time_utils.md
+++ b/doc/chef_time_utils.md
@@ -5,26 +5,22 @@
 * [Function Index](#index)
 * [Function Details](#functions)
 
-
 chef_time_utils - helpers for converting between http and erlang time.
+
 Copyright (c) 2011-2012 Opscode, Inc. All Rights Reserved.
 
 __Authors:__ Seth Falcon ([`seth@opscode.com`](mailto:seth@opscode.com)), Christopher Brown ([`cb@opscode.com`](mailto:cb@opscode.com)).
+
 <a name="description"></a>
 
 ## Description ##
-
-
 
 This file is provided to you under the Apache License,
 Version 2.0 (the "License"); you may not use this file
 except in compliance with the License.  You may obtain
 a copy of the License at
 
-
-
 http://www.apache.org/licenses/LICENSE-2.0
-
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
@@ -50,44 +46,35 @@ representation.</td></tr></table>
 
 ### canonical_time/1 ###
 
-
 <pre><code>
 canonical_time(T::string() | binary()) -&gt; <a href="#type-iso8601_time">iso8601_time()</a>
 </code></pre>
-
-<br></br>
-
+<br />
 
 Convert a string or binary HTTP request time to iso8601 format
+
 <a name="time_in_bounds-2"></a>
 
 ### time_in_bounds/2 ###
 
-
 <pre><code>
 time_in_bounds(ReqTime::undefined | string() | binary(), Skew::<a href="#type-time_skew">time_skew()</a>) -&gt; boolean() | invalid_reqtime
 </code></pre>
-
-<br></br>
-
-
+<br />
 
 Check if a time, expressed as an ISO8601 string is equal to the current time, within
 a given Skew interval.
 
-
 Returns invalid_reqtime if the ISO8601 time can't be parsed
+
 <a name="time_in_bounds-3"></a>
 
 ### time_in_bounds/3 ###
 
-
 <pre><code>
 time_in_bounds(T1::<a href="#type-erlang_time">erlang_time()</a>, T2::<a href="#type-erlang_time">erlang_time()</a>, Skew::<a href="#type-time_skew">time_skew()</a>) -&gt; boolean()
 </code></pre>
-
-<br></br>
-
+<br />
 
 Check if two times are equal within a given Skew interval.
 
@@ -95,30 +82,23 @@ Check if two times are equal within a given Skew interval.
 
 ### time_iso8601/1 ###
 
-
 <pre><code>
 time_iso8601(X1::<a href="#type-erlang_time">erlang_time()</a> | now) -&gt; binary()
 </code></pre>
-
-<br></br>
-
-
+<br />
 
 Converts Erlang time-tuple to iso8601 formatted date string.
 
-
 Example output looks like `<<"2003-12-13T18:30:02Z">>`
+
 <a name="time_iso8601_to_date_time-1"></a>
 
 ### time_iso8601_to_date_time/1 ###
 
-
 <pre><code>
 time_iso8601_to_date_time(ATime::string() | binary()) -&gt; <a href="#type-erlang_time">erlang_time()</a>
 </code></pre>
-
-<br></br>
-
+<br />
 
 Convert an iso8601 time string to Erlang date time
 representation.

--- a/doc/edoc-info
+++ b/doc/edoc-info
@@ -1,5 +1,4 @@
 %% encoding: UTF-8
 {application,chef_authn}.
-{packages,[]}.
 {modules,[chef_authn,chef_keygen_cache,chef_keygen_worker,
           chef_keygen_worker_sup,chef_keyring,chef_time_utils]}.

--- a/doc/stylesheet.css
+++ b/doc/stylesheet.css
@@ -27,10 +27,10 @@ div.spec {
  	margin-left: 2em;
 	background-color: #eeeeee;
 }
-a.module,a.package {
+a.module {
 	text-decoration:none
 }
-a.module:hover,a.package:hover {
+a.module:hover {
 	background-color: #eeeeee;
 }
 ul.definitions {

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -61,7 +61,7 @@ EDown = case proplists:get_value(use_edown, CONFIG) of
                 [DocOpts,
                  {deps,
                   [{edown, ".*",
-                    {git, "git://github.com/seth/edown.git",
+                    {git, "git://github.com/uwiger/edown.git",
                      {branch, "master"}}}]}]
            end,
 

--- a/src/chef_authn.erl
+++ b/src/chef_authn.erl
@@ -75,7 +75,7 @@
 -type key_desc() :: any().
 -type public_key_list() :: [{key_desc(), public_key_data() | rsa_public_key()}].
 
--type header_fun() :: fun((header_name()) -> header_value()).
+-type header_fun() :: undefined | fun((header_name()) -> header_value()).
 -type sign_parameter() :: {private_key, rsa_private_key()} |
                           {body, http_body()} |
                           {user, user_id()} |

--- a/src/chef_authn.erl
+++ b/src/chef_authn.erl
@@ -40,9 +40,6 @@
          extract_public_key/1,
          extract_pem_encoded_public_key/1,
          sign_request/2,
-         sign_request/5,
-         sign_request/6,
-         sign_request/8,
          authenticate_user_request/6,
          validate_headers/2
          ]).
@@ -51,7 +48,10 @@
 -export([accepted_signing_algorithm/1,
          default_signing_algorithm/0,
          hash_string/1,
-         hash_file/1
+         hash_file/1,
+         sign_request/5,
+         sign_request/6,
+         sign_request/8
         ]).
 
 -include_lib("public_key/include/public_key.hrl").

--- a/test/chef_authn_tests.erl
+++ b/test/chef_authn_tests.erl
@@ -420,7 +420,7 @@ verify_sig_v1_2_test() ->
 verify_sig_v1_3_sha256_test() ->
     Sig = iolist_to_binary(?X_OPS_AUTHORIZATION_LINES_V1_3_SHA256),
     Plain = ?expected_sign_string_v13_sha256,
-    {ok, Public_key} = file:read_file("test/example_cert.pem"),
+    {ok, Public_key} = file:read_file("../test/example_cert.pem"),
     ?assertEqual({name,<<"spec-user">>},
                  chef_authn:verify_sig(Plain, ignore, ignore,
                                        Sig,


### PR DESCRIPTION
`public_key` actually doesn't export them. Missing types hide errors in dialyzer, such as this one, did, too -- although it was just a spec issue, I think.

I haven't found out how to update the docs with the referenced `seth/edown`, but it seemed to work with `uwiger/edown` (and Erlang/OTP 18).
