### PR TITLE
Fix certificate encoding change

### DIFF
--- a/src/chef_authn.erl
+++ b/src/chef_authn.erl
@@ -162,7 +162,12 @@ process_key({'Certificate', _Der, _} = CertEntry) ->
     Cert = public_key:pem_entry_decode(CertEntry),
     TbsCert = Cert#'Certificate'.tbsCertificate,
     Spki = TbsCert#'TBSCertificate'.subjectPublicKeyInfo,
-    {0, KeyDer} = Spki#'SubjectPublicKeyInfo'.subjectPublicKey,
+    KeyDer = case Spki#'SubjectPublicKeyInfo'.subjectPublicKey of
+                 {0, KeyDerEncoded} -> %% OTP 17
+                     KeyDerEncoded;
+                 KeyDerEncoded ->      %% OTP 18+
+                     KeyDerEncoded
+             end,
     public_key:der_decode('RSAPublicKey', KeyDer);
 process_key({'PrivateKeyInfo', _, _} = Entry) ->
     KeyInfo = public_key:pem_entry_decode(Entry),


### PR DESCRIPTION
Apparently, some nested data in `#Certificate{}` has changed its
format...

This could also be done in `-ifdef`s.

Signed-off-by: Stephan Renatus <srenatus@chef.io>