### PR TITLE
Get this ready for OTP 18+, add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: false
+branches:
+  only:
+    - master
+
+language: erlang
+otp_release:
+  - 19.2
+  - 18.3
+  - 17.4
+script: make

--- a/rebar.config
+++ b/rebar.config
@@ -1,10 +1,13 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 ft=erlang et
 
+{erl_opts, [
+    {platform_define, "^(18|19|2)", otp_18_plus}
+]}.
+
 {cover_enabled, true}.
 {cover_print_enabled, true}.
 {deps, [
-          {envy, ".*",
-   {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}
-
- ]}.
+    {envy, ".*",
+     {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}
+]}.


### PR DESCRIPTION
In 1d2bf3b, we've forgotten `decode_cert/1`. This fixes that and introduces the macros to solve this
at compile time.