### PR TITLE
Add secrets_module option for getting secrets

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,5 +9,7 @@
 {cover_print_enabled, true}.
 {deps, [
     {envy, ".*",
-     {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}
+     {git, "git://github.com/manderson26/envy.git", {branch, "master"}}},
+    {meck, ".*",
+     {git, "git://github.com/eproxus/meck.git", {branch, "master"}}}
 ]}.

--- a/test/chef_authn_tests.erl
+++ b/test/chef_authn_tests.erl
@@ -126,6 +126,12 @@
                             1
                            ]))).
 
+test_dir(File) ->
+    filename:join(test_dir(), File).
+
+test_dir() ->
+    filename:join(code:priv_dir(chef_authn), "../test/").
+
 accepted_signing_protocol_test() ->
     %% All signing versions should accept default
     ?assertEqual(true, chef_authn:accepted_signing_protocol(default, ?SIGNING_VERSION_V1_0)),
@@ -189,9 +195,9 @@ hashed_body_test_helper([]) ->
     ok;
 hashed_body_test_helper([{SignInfo, ExpectedHash} | T]) ->
     ?assertEqual(ExpectedHash, chef_authn:hashed_body(?body, SignInfo)),
-    {ok, Fd} = file:open("../test/example_cert.pem", [read]),
+    {ok, Fd} = file:open(test_dir("example_cert.pem"), [read]),
     FileHash = chef_authn:hashed_body(Fd, SignInfo),
-    {ok, Bin} = file:read_file("../test/example_cert.pem"),
+    {ok, Bin} = file:read_file(test_dir("example_cert.pem")),
     ContentHashFromBin = chef_authn:hashed_body(Bin, SignInfo),
     ContentHashFromList = chef_authn:hashed_body(binary_to_list(Bin), SignInfo),
     ?assert(is_binary(FileHash)),
@@ -272,7 +278,7 @@ canonicalize_request_v_1_3_sha256_test() ->
 sign_request_1_0_test() ->
     Algorithm = chef_authn:default_signing_algorithm(),
     Version = <<"1.0">>,
-    {ok, RawKey} = file:read_file("../test/private_key"),
+    {ok, RawKey} = file:read_file(test_dir("private_key")),
     Private_key = chef_authn:extract_private_key(RawKey),
     AuthLine = fun(I) -> lists:nth(I, ?X_OPS_AUTHORIZATION_LINES_V1_0) end,
     EXPECTED_SIGN_RESULT =
@@ -295,7 +301,7 @@ sign_request_1_0_test() ->
 sign_request_1_1_test() ->
     Algorithm = chef_authn:default_signing_algorithm(),
     Version = <<"1.1">>,
-    {ok, RawKey} = file:read_file("../test/private_key"),
+    {ok, RawKey} = file:read_file(test_dir("private_key")),
     Private_key = chef_authn:extract_private_key(RawKey),
     AuthLine = fun(I) -> lists:nth(I, ?X_OPS_AUTHORIZATION_LINES_V1_1) end,
     EXPECTED_SIGN_RESULT =
@@ -318,7 +324,7 @@ sign_request_1_1_test() ->
 sign_request_1_2_test() ->
     Algorithm = chef_authn:default_signing_algorithm(),
     Version = <<"1.2">>,
-    {ok, RawKey} = file:read_file("../test/private_key"),
+    {ok, RawKey} = file:read_file(test_dir("private_key")),
     Private_key = chef_authn:extract_private_key(RawKey),
     AuthLine = fun(I) -> lists:nth(I, ?X_OPS_AUTHORIZATION_LINES_V1_2) end,
     EXPECTED_SIGN_RESULT =
@@ -341,7 +347,7 @@ sign_request_1_2_test() ->
 sign_request_1_3_sha256_test() ->
     Algorithm = <<"sha256">>,
     Version = <<"1.3">>,
-    {ok, RawKey} = file:read_file("../test/private_key"),
+    {ok, RawKey} = file:read_file(test_dir("private_key")),
     Private_key = chef_authn:extract_private_key(RawKey),
     AuthLine = fun(I) -> lists:nth(I, ?X_OPS_AUTHORIZATION_LINES_V1_3_SHA256) end,
     EXPECTED_SIGN_RESULT =
@@ -383,33 +389,33 @@ sign_bogus_request_test() ->
                                          <<"1.1">>)).
 
 key_type_cert_test() ->
-    {ok, Public_key} = file:read_file("../test/example_cert.pem"),
+    {ok, Public_key} = file:read_file(test_dir("example_cert.pem")),
     ?assertEqual(cert, chef_authn:key_type(Public_key)).
 
 key_type_pk_test() ->
-    {ok, Public_key} = file:read_file("../test/platform_public_key_example.pem"),
+    {ok, Public_key} = file:read_file(test_dir("platform_public_key_example.pem")),
     ?assertEqual(key, chef_authn:key_type(Public_key)).
 
 key_type_spki_pk_test() ->
-    {ok, Public_key} = file:read_file("../test/spki_public.pem"),
+    {ok, Public_key} = file:read_file(test_dir("spki_public.pem")),
     ?assertEqual(key, chef_authn:key_type(Public_key)).
 
 decrypt_sig_test() ->
     AuthSig = iolist_to_binary(?X_OPS_AUTHORIZATION_LINES_V1_0),
-    {ok, Public_key} = file:read_file("../test/example_cert.pem"),
+    {ok, Public_key} = file:read_file(test_dir("example_cert.pem")),
     ?assertEqual(?expected_sign_string_v10,
                  chef_authn:decrypt_sig(AuthSig, Public_key)).
 
 decrypt_sig_v1_1_test() ->
     AuthSig = iolist_to_binary(?X_OPS_AUTHORIZATION_LINES_V1_1),
-    {ok, Public_key} = file:read_file("../test/example_cert.pem"),
+    {ok, Public_key} = file:read_file(test_dir("example_cert.pem")),
     DecryptSig = chef_authn:decrypt_sig(AuthSig, Public_key),
     ?assertEqual(?expected_sign_string_v11, DecryptSig).
 
 verify_sig_v1_2_test() ->
     Sig = iolist_to_binary(?X_OPS_AUTHORIZATION_LINES_V1_2),
     Plain = ?expected_sign_string_v12,
-    {ok, Public_key} = file:read_file("../test/example_cert.pem"),
+    {ok, Public_key} = file:read_file(test_dir("example_cert.pem")),
     ?assertEqual({name,<<"spec-user">>},
                  chef_authn:verify_sig(Plain, ignore, ignore,
                                        Sig,
@@ -420,7 +426,7 @@ verify_sig_v1_2_test() ->
 verify_sig_v1_3_sha256_test() ->
     Sig = iolist_to_binary(?X_OPS_AUTHORIZATION_LINES_V1_3_SHA256),
     Plain = ?expected_sign_string_v13_sha256,
-    {ok, Public_key} = file:read_file("../test/example_cert.pem"),
+    {ok, Public_key} = file:read_file(test_dir("example_cert.pem")),
     ?assertEqual({name,<<"spec-user">>},
                  chef_authn:verify_sig(Plain, ignore, ignore,
                                        Sig,
@@ -429,16 +435,14 @@ verify_sig_v1_3_sha256_test() ->
                                        {<<"sha256">>, <<"1.3">>})).
 
 
-fetch_keys(BaseDir, Filenames) ->
-    Keys = [{N,K} || {N, {ok, K}} <-  [ {Name, file:read_file(iolist_to_binary([ BaseDir, Name]))} || Name <- Filenames ] ],
-    Keys.
-
-%% [ iolist_to_binary([ BaseDir, Name]) || Name <- Filenames ]
-
 verify_sigs_v1_2_test_() ->
     Sig = iolist_to_binary(?X_OPS_AUTHORIZATION_LINES_V1_2),
     Plain = ?expected_sign_string_v12,
-    KeyList = fetch_keys("../test/", ?KEYFILES),
+    KeyList = lists:map(fun(FileName) ->
+                                {ok, Content} = file:read_file(test_dir(FileName)),
+                                {FileName, Content}
+                        end,
+                        ?KEYFILES),
     [ fun() ->
               %% Test key in front of list
               AuthN = chef_authn:verify_sigs(Plain, ignore, ignore,
@@ -474,18 +478,18 @@ verify_sigs_v1_2_test_() ->
 
 decrypt_tagged_sig_test() ->
     AuthSig = iolist_to_binary(?X_OPS_AUTHORIZATION_LINES_V1_0),
-    {ok, Public_key} = file:read_file("../test/example_cert.pem"),
+    {ok, Public_key} = file:read_file(test_dir("example_cert.pem")),
     ?assertEqual(?expected_sign_string_v10,
                  chef_authn:decrypt_sig(AuthSig, Public_key)).
 
 decrypt_sig_fail_platform_style_test() ->
     AuthSig = iolist_to_binary(?X_OPS_AUTHORIZATION_LINES_V1_0),
-    {ok, Public_key} = file:read_file("../test/platform_public_key_example.pem"),
+    {ok, Public_key} = file:read_file(test_dir("platform_public_key_example.pem")),
     ?assertError(decrypt_failed, chef_authn:decrypt_sig(AuthSig, {key, Public_key})).
 
 decrypt_sig_fail_spki_test() ->
     AuthSig = iolist_to_binary(?X_OPS_AUTHORIZATION_LINES_V1_0),
-    {ok, Public_key} = file:read_file("../test/spki_public.pem"),
+    {ok, Public_key} = file:read_file(test_dir("spki_public.pem")),
     ?assertError(decrypt_failed, chef_authn:decrypt_sig(AuthSig, {key, Public_key})).
 
 make_skew_time() ->
@@ -497,9 +501,9 @@ make_skew_time() ->
     (NowEpoch - ReqTimeEpoch) + 100.
 
 authenticate_user_request_no_body_test_() ->
-    {ok, RawKey} = file:read_file("../test/private_key"),
+    {ok, RawKey} = file:read_file(test_dir("private_key")),
     Private_key = chef_authn:extract_private_key(RawKey),
-    {ok, Public_key} = file:read_file("../test/example_cert.pem"),
+    {ok, Public_key} = file:read_file(test_dir("example_cert.pem")),
     Headers0 = chef_authn:sign_request(Private_key, ?user, <<"get">>,
                                        now, ?path),
     %% We convert here back into binary keys in headers since that
@@ -525,13 +529,13 @@ authenticate_user_request_1_1_test_() ->
 authenticate_user_request_1_0_test_() ->
     authenticate_user_request_tests_by_version(<<"1.0">>).
 
-%% These tests exercice chef_uathn:authenticate_user_request/6 parameterized by the signing
+%% These tests exercise chef_uathn:authenticate_user_request/6 parameterized by the signing
 %% protocol version. As long as chef_authn:sign_request/8 supports signing, these tests
 %% should work.
 authenticate_user_request_tests_by_version(SignVersion) ->
-    {ok, RawKey} = file:read_file("../test/private_key"),
+    {ok, RawKey} = file:read_file(test_dir("private_key")),
     Private_key = chef_authn:extract_private_key(RawKey),
-    {ok, Public_key} = file:read_file("../test/example_cert.pem"),
+    {ok, Public_key} = file:read_file(test_dir("example_cert.pem")),
     Alg = chef_authn:default_signing_algorithm(SignVersion),
     Headers0 = chef_authn:sign_request(Private_key, ?body, ?user, <<"post">>,
                                        ?request_time_erlang, ?path, Alg, SignVersion),
@@ -600,7 +604,7 @@ authenticate_user_request_tests_by_version(SignVersion) ->
 
      {"no_authn: bad key",
       fun() ->
-              {ok, Other_key} = file:read_file("../test/other_cert.pem"),
+              {ok, Other_key} = file:read_file(test_dir("other_cert.pem")),
               BadKey = chef_authn:authenticate_user_request(GetHeader, <<"post">>, ?path,
                                                  ?body, Other_key,
                                                  TimeSkew),
@@ -677,7 +681,7 @@ authenticate_user_request_tests_by_version(SignVersion) ->
     ].
 
 validate_headers_test_() ->
-    {ok, RawKey} = file:read_file("../test/private_key"),
+    {ok, RawKey} = file:read_file(test_dir("private_key")),
     Private_key = chef_authn:extract_private_key(RawKey),
     Headers0 = chef_authn:sign_request(Private_key, ?body, ?user, <<"post">>,
                                        calendar:universal_time(), ?path),
@@ -698,9 +702,9 @@ validate_headers_test_() ->
         ++ MissingOneTests.
 
 bad_signing_protocol_test() ->
-    {ok, RawKey} = file:read_file("../test/private_key"),
+    {ok, RawKey} = file:read_file(test_dir("private_key")),
     Private_key = chef_authn:extract_private_key(RawKey),
-    {ok, Public_key} = file:read_file("../test/example_cert.pem"),
+    {ok, Public_key} = file:read_file(test_dir("example_cert.pem")),
     Alg = chef_authn:default_signing_algorithm(),
 
     %% v1.0 is chosen here just to make the request. We're going to replace
@@ -771,20 +775,20 @@ parse_signing_description_1_1_test_() ->
       || {In, Want} <- Cases ].
 
 decode_cert_test() ->
-    {ok, Bin} = file:read_file("../test/example_cert.pem"),
+    {ok, Bin} = file:read_file(test_dir("example_cert.pem")),
     Cert = chef_authn:decode_cert(Bin),
     ?assertEqual('RSAPublicKey', erlang:element(1, Cert)).
 
 decode_public_key_platform_test() ->
     %% platform-style key
-    {ok, Bin} = file:read_file("../test/platform_public_key_example.pem"),
+    {ok, Bin} = file:read_file(test_dir("platform_public_key_example.pem")),
     PubKey = chef_authn:decode_public_key(Bin),
     Coded = public_key:encrypt_public(<<"open sesame">>, PubKey),
     ?assertEqual(true, is_binary(Coded)).
 
 decode_public_key_spki_test() ->
     %% platform-style key
-    {ok, Bin} = file:read_file("../test/spki_public.pem"),
+    {ok, Bin} = file:read_file(test_dir("spki_public.pem")),
     %% verify valid key, by encrypting something, will error if
     %% key is bad.
     PubKey = chef_authn:decode_public_key(Bin),
@@ -794,34 +798,34 @@ decode_public_key_spki_test() ->
 extract_pem_encoded_public_key_test_() ->
     [{"CERTIFICATE",
       fun() ->
-              {ok, Pem} = file:read_file("../test/example_cert.pem"),
+              {ok, Pem} = file:read_file(test_dir("example_cert.pem")),
               Key = chef_authn:extract_pem_encoded_public_key(Pem),
               ?assertMatch(<<"-----BEGIN PUBLIC KEY",_Bin/binary>>, Key)
       end},
      {"PUBLIC KEY",
       fun() ->
-              {ok, Pem} = file:read_file("../test/spki_public.pem"),
+              {ok, Pem} = file:read_file(test_dir("spki_public.pem")),
               Key = chef_authn:extract_pem_encoded_public_key(Pem),
               ?assertEqual({error, bad_key}, Key)
       end},
      {"RSA PUBLIC KEY",
       fun() ->
-              {ok, Pem} = file:read_file("../test/webui_pub.pem"),
+              {ok, Pem} = file:read_file(test_dir("webui_pub.pem")),
               Key = chef_authn:extract_pem_encoded_public_key(Pem),
               ?assertEqual({error, bad_key}, Key)
       end},
      {"RSA PRIVATE KEY",
       fun() ->
-              {ok, Pem} = file:read_file("../test/private_key"),
+              {ok, Pem} = file:read_file(test_dir("private_key")),
               Key = chef_authn:extract_pem_encoded_public_key(Pem),
               ?assertEqual({error, bad_key}, Key)
       end},
      {"invalid cert returns error tuple", generator,
       fun() ->
 
-              {ok, Pem} = file:read_file("../test/example_cert.pem"),
+              {ok, Pem} = file:read_file(test_dir("example_cert.pem")),
               Pem2 = re:replace(Pem, "D", "0", [{return, binary}]),
-              {ok, Priv} = file:read_file("../test/private_key"),
+              {ok, Priv} = file:read_file(test_dir("private_key")),
               BadKeys = [Priv, Pem2, <<"">>, <<"abc">>,
                          term_to_binary([123, {x, x}])],
               [ ?_assertEqual({error, bad_key},
@@ -837,42 +841,42 @@ extract_pem_encoded_public_key_test_() ->
 extract_public_or_private_key_test_() ->
     [{"RSA PUBLIC KEY",
       fun() ->
-              {ok, Pem} = file:read_file("../test/webui_pub.pem"),
+              {ok, Pem} = file:read_file(test_dir("webui_pub.pem")),
               Key = chef_authn:extract_public_or_private_key(Pem),
               ?assert(Key#'RSAPublicKey'.modulus > 0)
       end},
 
      {"PUBLIC KEY",
       fun() ->
-              {ok, Pem} = file:read_file("../test/spki_public.pem"),
+              {ok, Pem} = file:read_file(test_dir("spki_public.pem")),
               Key = chef_authn:extract_public_or_private_key(Pem),
               ?assert(Key#'RSAPublicKey'.modulus > 0)
       end},
 
      {"CERTIFICATE",
       fun() ->
-              {ok, Pem} = file:read_file("../test/example_cert.pem"),
+              {ok, Pem} = file:read_file(test_dir("example_cert.pem")),
               Key = chef_authn:extract_public_or_private_key(Pem),
               ?assert(Key#'RSAPublicKey'.modulus > 0)
       end},
 
      {"RSA PRIVATE KEY",
       fun() ->
-              {ok, Pem} = file:read_file("../test/private_key"),
+              {ok, Pem} = file:read_file(test_dir("private_key")),
               Key = chef_authn:extract_public_or_private_key(Pem),
               ?assert(Key#'RSAPrivateKey'.prime1 > 0)
       end},
 
      {"RSA PRIVATE KEY PKCS#8",
       fun() ->
-              {ok, Pem} = file:read_file("../test/private_key_pkcs8"),
+              {ok, Pem} = file:read_file(test_dir("private_key_pkcs8")),
               Key = chef_authn:extract_public_or_private_key(Pem),
               ?assert(Key#'RSAPrivateKey'.prime1 > 0)
       end},
 
      {"UNSUPPORTED DSA PRIVATE KEY PKCS#8",
       fun() ->
-              {ok, Pem} = file:read_file("../test/private_key_pkcs8_dsa"),
+              {ok, Pem} = file:read_file(test_dir("private_key_pkcs8_dsa")),
               Key = chef_authn:extract_public_or_private_key(Pem),
               ?_assertEqual({error, bad_key}, Key)
       end},
@@ -880,7 +884,7 @@ extract_public_or_private_key_test_() ->
      {"invalid keys return error tuple", generator,
       fun() ->
               %% mangle a key
-              {ok, Pem} = file:read_file("../test/spki_public.pem"),
+              {ok, Pem} = file:read_file(test_dir("spki_public.pem")),
               Pem2 = re:replace(Pem, "A", "0", [{return, binary}]),
               BadKeys = [Pem2, <<"">>, <<"abc">>,
                          term_to_binary([123, {x, x}])],
@@ -893,28 +897,28 @@ extract_public_or_private_key_test_() ->
 extract_public_key_test_() ->
     [{"RSA PUBLIC KEY",
       fun() ->
-              {ok, Pem} = file:read_file("../test/webui_pub.pem"),
+              {ok, Pem} = file:read_file(test_dir("webui_pub.pem")),
               Key = chef_authn:extract_public_key(Pem),
               ?assert(Key#'RSAPublicKey'.modulus > 0)
       end},
 
      {"PUBLIC KEY",
       fun() ->
-              {ok, Pem} = file:read_file("../test/spki_public.pem"),
+              {ok, Pem} = file:read_file(test_dir("spki_public.pem")),
               Key = chef_authn:extract_public_key(Pem),
               ?assert(Key#'RSAPublicKey'.modulus > 0)
       end},
 
      {"CERTIFICATE",
       fun() ->
-              {ok, Pem} = file:read_file("../test/example_cert.pem"),
+              {ok, Pem} = file:read_file(test_dir("example_cert.pem")),
               Key = chef_authn:extract_public_key(Pem),
               ?assert(Key#'RSAPublicKey'.modulus > 0)
       end},
 
      {"RSA PRIVATE KEY is",
       fun() ->
-              {ok, Pem} = file:read_file("../test/private_key"),
+              {ok, Pem} = file:read_file(test_dir("private_key")),
               Key = chef_authn:extract_public_or_private_key(Pem),
               ?assert(Key#'RSAPrivateKey'.prime1 > 0)
       end},
@@ -922,9 +926,9 @@ extract_public_key_test_() ->
      {"invalid keys return error tuple", generator,
       fun() ->
               %% mangle a key
-              {ok, Pem} = file:read_file("../test/spki_public.pem"),
+              {ok, Pem} = file:read_file(test_dir("spki_public.pem")),
               Pem2 = re:replace(Pem, "A", "0", [{return, binary}]),
-              {ok, Priv} = file:read_file("../test/private_key"),
+              {ok, Priv} = file:read_file(test_dir("private_key")),
               BadKeys = [Priv, Pem2, <<"">>, <<"abc">>,
                          term_to_binary([123, {x, x}])],
               [ ?_assertEqual({error, bad_key},
@@ -936,7 +940,7 @@ extract_public_key_test_() ->
 extract_private_key_test_() ->
     [{"RSA PRIVATE KEY",
       fun() ->
-              {ok, Pem} = file:read_file("../test/private_key"),
+              {ok, Pem} = file:read_file(test_dir("private_key")),
               Key = chef_authn:extract_private_key(Pem),
               ?assert(Key#'RSAPrivateKey'.prime1 > 0)
       end},
@@ -944,11 +948,11 @@ extract_private_key_test_() ->
      {"invalid keys return error tuple", generator,
       fun() ->
               %% mangle a key
-              {ok, Pem} = file:read_file("../test/spki_public.pem"),
+              {ok, Pem} = file:read_file(test_dir("spki_public.pem")),
               Munged = re:replace(Pem, "A", "0", [{return, binary}]),
-              {ok, Cert} = file:read_file("../test/example_cert.pem"),
-              {ok, Pub1} = file:read_file("../test/webui_pub.pem"),
-              {ok, Pub2} = file:read_file("../test/spki_public.pem"),
+              {ok, Cert} = file:read_file(test_dir("example_cert.pem")),
+              {ok, Pub1} = file:read_file(test_dir("webui_pub.pem")),
+              {ok, Pub2} = file:read_file(test_dir("spki_public.pem")),
               BadKeys = [Munged, Cert, Pub1, Pub2,
                          <<"">>, <<"abc">>,
                          term_to_binary([123, {x, x}])],
@@ -959,9 +963,9 @@ extract_private_key_test_() ->
     ].
 
 hash_file_test() ->
-    {ok, Fd} = file:open("../test/example_cert.pem", [read]),
+    {ok, Fd} = file:open(test_dir("example_cert.pem"), [read]),
     FileHash = chef_authn:hash_file(Fd),
-    {ok, Bin} = file:read_file("../test/example_cert.pem"),
+    {ok, Bin} = file:read_file(test_dir("example_cert.pem")),
     ContentHash = chef_authn:hash_string(Bin),
     ?assert(is_binary(FileHash)),
     ?assertEqual(ContentHash, FileHash).


### PR DESCRIPTION
This allows for getting secrets from "some other place", identified as a
callback in the application environment under chef_authn/secrets_module:

With an appplication environment like this:

    {chef_authn, [
        {secrets_module, {chef_secrets, get,
                             [{pivotal, [<<"chef-server">>, <<"superuser_key">>]},
                              {webui, [<<"chef-server">>, <<"webui_key">>]}]}
        }
    ]}.

chef_keyring will call `chef_secrets:get(<<"chef-server">>, <<"superuser_key">>)`
to get the key named `pivotal`, and analogously for the key named webui.