### PR TITLE
Remove macro completely

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,10 +1,6 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 ft=erlang et
 
-{erl_opts, [
-    {platform_define, "^(18|19|2)", otp_18_plus}
-]}.
-
 {cover_enabled, true}.
 {cover_print_enabled, true}.
 {deps, [

--- a/src/chef_authn.erl
+++ b/src/chef_authn.erl
@@ -83,11 +83,6 @@
                           {time, erlang_time() | now} |
                           {path, http_path()} |
                           {get_header, header_fun()}.
--ifdef(otp_18_plus).
--define(ensure_binary(X), X).
--else.
--define(ensure_binary(X), erlang:list_to_binary(X)).
--endif.
 
 -ifdef(TEST).
 -compile([export_all]).
@@ -172,7 +167,7 @@ process_key({'PrivateKeyInfo', _, _} = Entry) ->
     case KeyAlgorithmInfo of
         #'PrivateKeyInfo_privateKeyAlgorithm'{algorithm=?'rsaEncryption'} ->
             PrivateKey = KeyInfo#'PrivateKeyInfo'.privateKey,
-            public_key:der_decode('RSAPrivateKey', ?ensure_binary(PrivateKey));
+            public_key:der_decode('RSAPrivateKey', ensure_binary(PrivateKey));
         _ ->
             {error, bad_key}
     end.
@@ -743,3 +738,6 @@ public_key_from_spki(Spki) ->
 
 get_key_der({0, Bin}) when is_binary(Bin)-> Bin;
 get_key_der(Bin) when is_binary(Bin)-> Bin.
+
+ensure_binary(Bin) when is_binary(Bin) -> Bin;
+ensure_binary(List) when is_list(List) -> erlang:list_to_binary(List).


### PR DESCRIPTION
We suspect that not having the otp_18_plus platform_define might have
caused issues somewhere else, so let's get rid of this.
