### PR TITLE
Use absolute value of time diff when doing skew check.

### DIFF
--- a/src/chef_time_utils.erl
+++ b/src/chef_time_utils.erl
@@ -83,6 +83,4 @@ time_in_bounds(ReqTime, Skew) ->
 time_in_bounds(T1, T2, Skew) when is_integer(Skew) ->
     S1 = calendar:datetime_to_gregorian_seconds(T1),
     S2 = calendar:datetime_to_gregorian_seconds(T2),
-    (S2 - S1) < Skew.
-
-
+    erlang:abs(S2 - S1) < Skew.

--- a/test/chef_time_utils_tests.erl
+++ b/test/chef_time_utils_tests.erl
@@ -36,10 +36,15 @@ time_in_bounds_test() ->
     ?assertEqual(false, chef_time_utils:time_in_bounds(T1, T4, 60*60)),
     ?assertEqual(true, chef_time_utils:time_in_bounds(T1, T4, 60*60*3)).
 
+time_from_the_future_test() ->
+    T1 = {{2011,1,26},{2,3,4}},
+    T2 = {{2011,1,26},{2,3,0}},
+    ?assertEqual(false, chef_time_utils:time_in_bounds(T1, T2, 2)),
+    ?assertEqual(true, chef_time_utils:time_in_bounds(T1, T2, 5)).
+
 %% We expect no function match when Skew is undefined
 undefined_skew_test() ->
     T1 = {{2011,1,26},{2,3,0}},
     T2 = {{2011,1,26},{2,3,4}},
 
     ?assertError(function_clause, chef_time_utils:time_in_bounds(T1, T2, undefined)).
-


### PR DESCRIPTION
Previously, this check would always return true if s2 < s1.  In the
context of the chef-server, this implies that requests from the future
always passed the time check. Using the absolute value of the
difference ensure both future and past requests will get 401s.

Signed-off-by: Steven Danna <steve@chef.io>