### PR TITLE
Cleanup openssl keygen process when it times out.

### DIFF
--- a/src/chef_keygen_worker.erl
+++ b/src/chef_keygen_worker.erl
@@ -146,6 +146,9 @@ gather_data(Port, Timeout, Acc) ->
         {Port, {data, {eol, Line}}} ->
             gather_data(Port, Timeout, ["\n", Line | Acc])
     after Timeout ->
+            %% Don't just abandon the process if the process ran too long, clean it up as well.
+            {os_pid, OsPid} = erlang:port_info(Port, os_pid),
+            os:cmd(io_lib:format("kill -9 ~p", [OsPid])),
             keygen_timeout
     end.
 


### PR DESCRIPTION
NOTE: Still testing this
On a heavily loaded system keygen can take some time, and the timeout
fires while it's still doing work. Right now we orphan the
process. This change cleans up after ourselves.

Signed-off-by: Mark Anderson <mark@chef.io>