### PR TITLE
avoid printing key information to logs

### DIFF
--- a/src/chef_authn.erl
+++ b/src/chef_authn.erl
@@ -168,12 +168,10 @@ process_key({'PrivateKeyInfo', Der, _} = Entry) ->
     %% Arguably this could be done with an ifdef and an erlang version test.
     case KeyInfo of
         #'PrivateKeyInfo'{privateKeyAlgorithm=#'PrivateKeyInfo_privateKeyAlgorithm'{algorithm=?'rsaEncryption'}, privateKey=PrivateKey} ->
-            io:format("KeyInfo ~p~nPK ~p~n", [KeyInfo, PrivateKey]),
             public_key:der_decode('RSAPrivateKey', ensure_binary(PrivateKey));
         #'RSAPrivateKey'{} -> %% OTP-21 decodes fully
             KeyInfo;
         _ ->
-            io:format("KeyInfo ~p~n", [KeyInfo]),
             {error, bad_key}
     end.
 


### PR DESCRIPTION
This looks like it might be leftover from debugging. While I imagine
this output might be useful in some cases, it currently results in
PKs being printed to the log.

Signed-off-by: Steven Danna <steve@chef.io>